### PR TITLE
Save static eval to TT if no ttHit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -278,6 +278,7 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     }
     else {
         eval = stack->staticEval = evaluate(board);
+        ttEntry->update(board->stack->hash, MOVE_NONE, 0, eval, EVAL_NONE, ttPv, TT_NOBOUND);
     }
 
     // Improving

--- a/src/tt.h
+++ b/src/tt.h
@@ -34,6 +34,10 @@ struct TTEntry {
     Eval value = EVAL_NONE;
 
     void update(uint64_t _hash, Move _bestMove, uint8_t _depth, Eval _eval, Eval _value, bool wasPv, int flags) {
+        // Don't overwrite ttMoves
+        if (_bestMove == MOVE_NONE && bestMove != MOVE_NONE)
+            return;
+        
         hash = (uint32_t)_hash;
         bestMove = _bestMove;
         depth = _depth;


### PR DESCRIPTION
https://openbench.yoshie2000.de/test/233/
With non-regression bounds this test would have passed, which is good enough:
```
python3 sprt.py --wins 4674 --losses 4586 --draws 6532 --elo0 -4 --elo1 1 --beta 0.1
ELO: 1.94 +- 4.14 [-2.21, 6.08]
LLR: 2.94 [-4.0, 1.0] (-2.25, 2.89)
H1 Accepted
```

Bench: 8444756