### PR TITLE
Singular extensions

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -54,6 +54,7 @@ struct SearchParameters {
 
 struct SearchData {
     int nmpPlies;
+    int rootDepth;
 
     bool stopSearching;
     uint64_t nodesSearched;

--- a/src/types.h
+++ b/src/types.h
@@ -58,5 +58,6 @@ struct SearchStack {
     Move move;
     Piece movedPiece;
 
+    Move excludedMove;
     Move killers[2];
 };


### PR DESCRIPTION
STC:
```
Elo   | 23.36 +- 10.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2100 W: 616 L: 475 D: 1009
Penta | [29, 211, 453, 304, 53]
https://openbench.yoshie2000.de/test/257/
```
LTC:
```
Elo   | 20.18 +- 10.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [0.50, 5.50]
Games | N: 2206 W: 597 L: 469 D: 1140
Penta | [21, 201, 534, 323, 24]
https://openbench.yoshie2000.de/test/258/
```

Bench: 10987337