### PR TITLE
Negative extension when ttValue beats beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -506,6 +506,9 @@ movesLoop:
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node
             else if (singularBeta >= beta)
                 return singularBeta;
+            // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
+            else if (ttValue >= beta)
+                extension = -2;
         }
 
         // Some setup stuff


### PR DESCRIPTION
STC:
```
Elo   | 7.52 +- 5.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6608 W: 1689 L: 1546 D: 3373
Penta | [64, 738, 1575, 845, 82]
https://openbench.yoshie2000.de/test/309/
```
LTC:
```
Elo   | 9.61 +- 6.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.50, 5.50]
Games | N: 4556 W: 1115 L: 989 D: 2452
Penta | [12, 492, 1160, 586, 28]
https://openbench.yoshie2000.de/test/310/
```

Bench: 3891145