### PR TITLE
History reductions

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -94,11 +94,6 @@ int* getCaptureHistory(Board* board, Move move) {
     if (capturedPiece == NO_PIECE && (move & 0x3000) != 0) // for ep and promotions, just take pawns
         capturedPiece = PIECE_PAWN;
 
-    if (movedPiece == NO_PIECE || capturedPiece == NO_PIECE) {
-        debugBoard(board);
-        std::cout << moveToString(move) << std::endl;
-    }
-
     assert(movedPiece != NO_PIECE && capturedPiece != NO_PIECE);
 
     return &captureHistory[board->stm][movedPiece][target][capturedPiece];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -552,6 +552,8 @@ movesLoop:
             if (cutNode)
                 reducedDepth--;
 
+            reducedDepth += moveHistory / 8192;
+
             reducedDepth = std::clamp(reducedDepth, 1, newDepth);
             value = -search<NON_PV_NODE>(board, stack + 1, thread, reducedDepth, -(alpha + 1), -alpha, true);
 


### PR DESCRIPTION
```
Elo   | 2.52 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 37388 W: 9515 L: 9244 D: 18629
Penta | [364, 4469, 8860, 4534, 467]
https://openbench.yoshie2000.de/test/321/
```

Bench: 3206239