### PR TITLE
If move not singular and expected to fail low, reduce depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -522,6 +522,9 @@ movesLoop:
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
             else if (ttValue >= beta)
                 extension = -2;
+            // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low 2 different ways, so reduce
+            else if (cutNode && ttValue <= alpha)
+                extension = -1;
         }
 
         // Some setup stuff


### PR DESCRIPTION
STC
```
Elo   | 6.70 +- 5.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7576 W: 1925 L: 1779 D: 3872
Penta | [72, 857, 1803, 965, 91]
https://openbench.yoshie2000.de/test/347/
```

LTC
```
Elo   | 9.31 +- 6.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.50, 5.50]
Games | N: 4740 W: 1160 L: 1033 D: 2547
Penta | [15, 513, 1197, 620, 25]
https://openbench.yoshie2000.de/test/349/
```

Bench: 3211223