### PR TITLE
Double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -523,6 +523,10 @@ movesLoop:
             if (singularValue < singularBeta) {
                 // This move is singular and we should investigate it further
                 extension = 1;
+                if (!pvNode && singularValue + 25 < singularBeta && stack->doubleExtensions <= 12) {
+                    extension = 2;
+                    stack->doubleExtensions = (stack - 1)->doubleExtensions + 1;
+                }
             }
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node
             else if (singularBeta >= beta)

--- a/src/types.h
+++ b/src/types.h
@@ -53,4 +53,6 @@ struct SearchStack {
 
     Move excludedMove;
     Move killers[2];
+
+    int doubleExtensions;
 };


### PR DESCRIPTION
STC
```
Elo   | 3.46 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20300 W: 5160 L: 4958 D: 10182
Penta | [248, 2344, 4743, 2588, 227]
https://openbench.yoshie2000.de/test/357/
```

LTC
```
Elo   | 7.44 +- 5.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.50, 5.50]
Games | N: 5930 W: 1401 L: 1274 D: 3255
Penta | [13, 630, 1554, 753, 15]
https://openbench.yoshie2000.de/test/358/
```

Bench: 3759774