### PR TITLE
Check for stop during nmp and after undoMove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -278,6 +278,9 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
         undoMove(board, move, &thread->nnue);
         assert(value > -EVAL_INFINITE && value < EVAL_INFINITE);
 
+        if (!thread->searching || thread->exiting)
+            return 0;
+
         if (value > bestValue) {
             bestValue = value;
             bestMove = move;
@@ -292,7 +295,6 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
                     break;
             }
         }
-
     }
 
     // Insert into TT
@@ -447,6 +449,9 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
         doNullMove(board, &boardStack);
         Eval nullValue = -search<NON_PV_NODE>(board, stack + 1, thread, depth - R, -beta, -beta + 1, !cutNode);
         undoNullMove(board);
+
+        if (!thread->searching || thread->exiting)
+            return 0;
 
         if (nullValue >= beta) {
             if (nullValue > EVAL_MATE_IN_MAX_PLY)
@@ -613,6 +618,9 @@ movesLoop:
 
         undoMove(board, move, &thread->nnue);
         assert(value > -EVAL_INFINITE && value < EVAL_INFINITE);
+
+        if (!thread->searching || thread->exiting)
+            return 0;
 
         if (value > bestValue) {
             bestValue = value;


### PR DESCRIPTION
This dramatically improves lazy SMP performance (4 threads vs. 1 thread):
```
Elo   | 131.74 +- 22.19 (95%)
Conf  | 8.0+0.08s Threads=4 Hash=64MB
Games | N: 500 W: 219 L: 38 D: 243
Penta | [1, 2, 89, 131, 27]
https://openbench.yoshie2000.de/test/390/
```
This easily passes an SPRT:
```
python3 sprt.py --wins 219 --losses 38 --draws 243 --elo0 0 --elo1 5
LLR: 4.11 [0.0, 5.0] (-2.94, 2.94)
```

Bench: 2992548