### PR TITLE
Save static eval in tt in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -215,7 +215,8 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
     bool ttHit = false;
     TTEntry* ttEntry = nullptr;
     Move ttMove = MOVE_NONE;
-    Eval ttValue = EVAL_NONE, ttEval = EVAL_NONE;
+    Eval ttValue = EVAL_NONE;
+    Eval ttEval = EVAL_NONE;
     uint8_t ttFlag = TT_NOBOUND;
     bool ttPv = pvNode;
 
@@ -232,7 +233,13 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
     if (!pvNode && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
-    stack->staticEval = bestValue = ttHit && ttEval != EVAL_NONE ? ttEval : evaluate(board, &thread->nnue);
+    if (ttHit && ttEval != EVAL_NONE) {
+        stack->staticEval = bestValue = ttEval;
+    }
+    else {
+        stack->staticEval = bestValue = evaluate(board, &thread->nnue);
+        ttEntry->update(board->stack->hash, MOVE_NONE, 0, stack->staticEval, EVAL_NONE, ttPv, TT_NOBOUND);
+    }
     futilityValue = stack->staticEval + qsFutilityOffset;
 
     // Stand pat


### PR DESCRIPTION
```
Elo   | 4.01 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15578 W: 3930 L: 3750 D: 7898
Penta | [155, 1842, 3615, 2022, 155]
https://openbench.yoshie2000.de/test/381/
```

Bench: 3086469