### PR TITLE
Fix SMP Crashes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -796,49 +796,6 @@ void Thread::tsearch() {
     result.finished = true;
 
     if (mainThread) {
-        // The main thread stops all other threads and does some naive voting over the best move
-        threadPool->stopSearching();
-        bool allFinished = false;
-        while (!allFinished && threadPool->threads.size() > 1) {
-            allFinished = true;
-            for (auto& th : threadPool->threads) {
-                if (!th.get()->result.finished)
-                    allFinished = false;
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-
-        // std::map<Move, int64_t> votes;
-        // Eval minValue = EVAL_INFINITE;
-        // ThreadResult* bestResult = &threadPool->threads[0].get()->result;
-
-        // if (threadPool->threads.size() > 1) {
-        //     for (auto& th : threadPool->threads) {
-        //         minValue = std::min(minValue, th.get()->result.value);
-        //     }
-        //     minValue++;
-
-        //     for (auto& th : threadPool->threads) {
-        //         ThreadResult* thResult = &th.get()->result;
-
-        //         // Votes weighted by depth and difference to the minimum value + 1
-        //         votes[thResult->move] += (thResult->value - minValue) * thResult->depth;
-
-        //         // In case of checkmate, take the shorter mate / longer getting mated
-        //         if (std::abs(bestResult->value) >= EVAL_MATE_IN_MAX_PLY) {
-        //             if (thResult->value > bestResult->value)
-        //                 bestResult = thResult;
-        //         }
-        //         // We have found a mate, take it without voting
-        //         else if (thResult->value >= EVAL_MATE_IN_MAX_PLY) {
-        //             bestResult = thResult;
-        //         }
-        //         // No mate found by any thread so far, take the thread with more votes
-        //         else if (votes[thResult->move] > votes[bestResult->move])
-        //             bestResult = thResult;
-        //     }
-        // }
-
         int64_t ms = getTime() - searchData.startTime;
         int64_t nodes = threadPool->nodesSearched();
         int64_t nps = ms == 0 ? 0 : nodes / ((double)ms / 1000);


### PR DESCRIPTION
Remove waiting for other threads.
Old vs. threadVoting:
```
Elo   | -7.27 +- 8.06 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3488 W: 816 L: 889 D: 1783
Penta | [40, 434, 850, 399, 21]
https://openbench.yoshie2000.de/test/391/
```
New vs. threadVoting:
```
Elo   | -13.58 +- 10.75 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2074 W: 495 L: 576 D: 1003
Penta | [30, 267, 504, 226, 10]
https://openbench.yoshie2000.de/test/394/
```
There's no visible elo loss vs. an equally strong opponent, and no crashes by the new version.

Bench: 3086469