### PR TITLE
Don't evaluate for checks in qsearch

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -12,6 +12,8 @@ const Eval PIECE_VALUES[PIECE_TYPES + 1] = {
 };
 
 Eval evaluate(Board* board, NNUE* nnue) {
+    assert(!board->stack->checkers);
+
     Eval eval = nnue->evaluate(board->stm);
 
     eval = eval * (220 - board->stack->rule50_ply) / 220;

--- a/src/move.h
+++ b/src/move.h
@@ -191,7 +191,7 @@ public:
     MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(onlyCaptures), killers{ MOVE_NONE, MOVE_NONE }, moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), flaggedBadCaptures(0), returnedBadCaptures(0), generationStage(GEN_STAGE_TTMOVE), depth(depth) {
         std::fill(moveList, moveList + MAX_MOVES, MOVE_NONE);
         std::fill(badCaptureList, badCaptureList + 32, MOVE_NONE);
-        counterMove = MOVE_NONE;
+        counterMove = onlyCaptures || searchStack->ply == 0 ? MOVE_NONE : history->getCounterMove((searchStack - 1)->move);
     }
 
     Move nextMove();


### PR DESCRIPTION
```
Elo   | 1.18 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 19214 W: 4503 L: 4438 D: 10273
Penta | [106, 2299, 4750, 2328, 124]
https://openbench.yoshie2000.de/test/450/
```

Bench: 2688317