### PR TITLE
Don't precalculate feature offsets

### DIFF
--- a/src/nnue.h
+++ b/src/nnue.h
@@ -205,7 +205,6 @@ struct NetworkData {
 };
 
 extern NetworkData networkData;
-alignas(ALIGNMENT) extern int cachedFeatureOffsets[2][PIECE_TYPES * 2 + 1][64];
 
 void initNetworkData();
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -83,7 +83,7 @@ public:
         exit();
     }
 
-    void resize(int numThreads) {
+    __attribute_noinline__ void resize(int numThreads) {
         exit();
         threads.clear();
         for (int i = 0; i < numThreads; i++) {
@@ -91,7 +91,7 @@ public:
         }
     }
 
-    void startSearching(Board board, std::deque<BoardStack> stackQueue, SearchParameters parameters) {
+    __attribute_noinline__ void startSearching(Board board, std::deque<BoardStack> stackQueue, SearchParameters parameters) {
         waitForSearchFinished();
 
         rootBoard = std::move(board);
@@ -108,32 +108,32 @@ public:
         }
     }
 
-    void stopSearching() {
+    __attribute_noinline__ void stopSearching() {
         for (auto& thread : threads) {
             thread.get()->searching = false;
         }
     }
 
-    void waitForSearchFinished() {
+    __attribute_noinline__ void waitForSearchFinished() {
         for (auto& thread : threads) {
             thread.get()->waitForSearchFinished();
         }
     }
 
-    void exit() {
+    __attribute_noinline__ void exit() {
         for (auto& thread : threads) {
             thread.get()->exit();
         }
     }
 
-    void ucinewgame() {
+    __attribute_noinline__ void ucinewgame() {
         TT.clear();
         for (auto& thread : threads) {
             thread.get()->ucinewgame();
         }
     }
 
-    uint64_t nodesSearched() {
+    __attribute_noinline__ uint64_t nodesSearched() {
         uint64_t sum = 0;
         for (auto& thread : threads) {
             sum += thread.get()->searchData.nodesSearched;


### PR DESCRIPTION
This commit is non-functional and gives a 3-8% speedup between a variety of machines.

It easily passes a non-regression SPRT:
```
Elo   | 1.61 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.52 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21560 W: 5119 L: 5019 D: 11422
Penta | [130, 2373, 5675, 2471, 131]
https://openbench.yoshie2000.de/test/479/
```

```
python3 sprt.py --wins 5119 --losses 5019 --draws 11422 --elo0 -4 --elo1 1
ELO: 1.61 +- 3.18 [-1.56, 4.79]
LLR: 3.68 [-4.0, 1.0] (-2.94, 2.94)
H1 Accepted
```

Bench: 2556703