### PR TITLE
Allocate less stuff during search

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -21,7 +21,7 @@ void History::initHistory() {
 Eval History::correctStaticEval(Eval eval, Board* board) {
     Eval history = getCorrectionHistory(board);
     Eval adjustedEval = eval + (history * std::abs(history)) / 16384;
-    adjustedEval = std::clamp((int) adjustedEval, (int) -EVAL_MATE_IN_MAX_PLY + 1, (int) EVAL_MATE_IN_MAX_PLY - 1);
+    adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_MATE_IN_MAX_PLY + 1, (int)EVAL_MATE_IN_MAX_PLY - 1);
     return adjustedEval;
 }
 
@@ -33,7 +33,8 @@ void History::updateCorrectionHistory(Board* board, int bonus) {
 int History::getHistory(Board* board, SearchStack* searchStack, Move move, bool isCapture) {
     if (isCapture) {
         return *getCaptureHistory(board, move);
-    } else {
+    }
+    else {
         return getQuietHistory(board, move) + 2 * getContinuationHistory(board, searchStack, move);
     }
 }
@@ -56,47 +57,40 @@ int History::getContinuationHistory(Board* board, SearchStack* stack, Move move)
     assert(piece != NO_PIECE);
 
     int score = 0;
-    if (stack->ply > 0) {
-        if ((stack - 1)->move != MOVE_NULL)
-            score += continuationHistory[board->stm][(stack - 1)->movedPiece][moveTarget((stack - 1)->move)][piece][target];
 
-        if (stack->ply > 1) {
-            if ((stack - 2)->move != MOVE_NULL)
-                score += continuationHistory[board->stm][(stack - 2)->movedPiece][moveTarget((stack - 2)->move)][piece][target];
+    if ((stack - 1)->movedPiece != NO_PIECE)
+        score += continuationHistory[board->stm][(stack - 1)->movedPiece][moveTarget((stack - 1)->move)][piece][target];
 
-            if (stack->ply > 3 && (stack - 4)->move != MOVE_NULL) {
-                score += continuationHistory[board->stm][(stack - 4)->movedPiece][moveTarget((stack - 4)->move)][piece][target];
-            }
-        }
-    }
+    if ((stack - 2)->movedPiece != NO_PIECE)
+        score += continuationHistory[board->stm][(stack - 2)->movedPiece][moveTarget((stack - 2)->move)][piece][target];
+
+    if ((stack - 4)->movedPiece != NO_PIECE)
+        score += continuationHistory[board->stm][(stack - 4)->movedPiece][moveTarget((stack - 4)->move)][piece][target];
+
     return score;
 }
 
 void History::updateContinuationHistory(Board* board, SearchStack* stack, Move move, int bonus) {
     // Update continuationHistory
-    if (stack->ply > 0) {
-        Piece piece = board->pieces[moveOrigin(move)];
-        if (piece == NO_PIECE)
-            piece = board->pieces[moveTarget(move)];
-        assert(piece != NO_PIECE);
-        Square target = moveTarget(move);
+    Piece piece = board->pieces[moveOrigin(move)];
+    if (piece == NO_PIECE)
+        piece = board->pieces[moveTarget(move)];
+    assert(piece != NO_PIECE);
+    Square target = moveTarget(move);
 
-        assert(piece != NO_PIECE);
+    assert(piece != NO_PIECE);
 
-        int scaledBonus = bonus - getContinuationHistory(board, stack, move) * std::abs(bonus) / 32768;
+    int scaledBonus = bonus - getContinuationHistory(board, stack, move) * std::abs(bonus) / 32768;
 
-        if ((stack - 1)->move != MOVE_NULL)
-            continuationHistory[board->stm][(stack - 1)->movedPiece][moveTarget((stack - 1)->move)][piece][target] += scaledBonus;
+    if ((stack - 1)->movedPiece != NO_PIECE)
+        continuationHistory[board->stm][(stack - 1)->movedPiece][moveTarget((stack - 1)->move)][piece][target] += scaledBonus;
 
-        if (stack->ply > 1) {
-            if ((stack - 2)->move != MOVE_NULL)
-                continuationHistory[board->stm][(stack - 2)->movedPiece][moveTarget((stack - 2)->move)][piece][target] += scaledBonus;
+    if ((stack - 2)->movedPiece != NO_PIECE)
+        continuationHistory[board->stm][(stack - 2)->movedPiece][moveTarget((stack - 2)->move)][piece][target] += scaledBonus;
 
-            if (stack->ply > 3 && (stack - 4)->move != MOVE_NULL) {
-                continuationHistory[board->stm][(stack - 4)->movedPiece][moveTarget((stack - 4)->move)][piece][target] += scaledBonus;
-            }
-        }
-    }
+    if ((stack - 4)->movedPiece != NO_PIECE)
+        continuationHistory[board->stm][(stack - 4)->movedPiece][moveTarget((stack - 4)->move)][piece][target] += scaledBonus;
+
 }
 
 int* History::getCaptureHistory(Board* board, Move move) {

--- a/src/move.h
+++ b/src/move.h
@@ -180,8 +180,8 @@ class MoveGen {
     int returnedMoves;
     int killerCount;
 
-    Move badCaptureList[32]; // There can never be more than 32 pieces on the board => never more than 32 captures possible
-    int badCaptureScores[32];
+    Move badCaptureList[48]; // There can never be more than 32 pieces on the board => never more than 32 captures possible
+    int badCaptureScores[48];
     int generatedBadCaptures; // Bad captures only count as "generated" when the corresponding stage sorts them
     int flaggedBadCaptures; // Before that, this counter will keep track of them
     int returnedBadCaptures;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -163,11 +163,12 @@ uint64_t perft(Board* board, int depth) {
     return nodes;
 }
 
-void updatePv(Move* pv, Move move, const Move* currentPv) {
-    *pv++ = move;
-    while (currentPv && *currentPv != MOVE_NONE)
-        *pv++ = *currentPv++;
-    *pv = MOVE_NONE;
+void updatePv(SearchStack* stack, Move move) {
+    stack->pvLength = (stack + 1)->pvLength;
+    stack->pv[stack->ply] = move;
+
+    for (int i = stack->ply + 1; i < (stack + 1)->pvLength; i++)
+        stack->pv[i] = (stack + 1)->pv[i];
 }
 
 int valueToTT(int value, int ply) {
@@ -192,6 +193,8 @@ template <NodeType nodeType>
 Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval beta) {
     constexpr bool pvNode = nodeType == PV_NODE;
 
+    if (pvNode)
+        stack->pvLength = stack->ply;
     thread->searchData.selDepth = std::max(stack->ply, thread->searchData.selDepth);
 
     assert(alpha >= -EVAL_INFINITE && alpha < beta && beta <= EVAL_INFINITE);
@@ -204,17 +207,9 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
         return (stack->ply >= MAX_PLY && !board->stack->checkers) ? evaluate(board, &thread->nnue) : drawEval(thread);
 
     BoardStack boardStack;
-    Move pv[MAX_PLY + 1] = { MOVE_NONE };
     Move bestMove = MOVE_NONE;
     Eval bestValue, futilityValue, unadjustedEval;
     Eval oldAlpha = alpha;
-
-    // Set up pv for the next search
-    if (pvNode) {
-        (stack + 1)->pv = pv;
-        stack->pv[0] = MOVE_NONE;
-    }
-    (stack + 1)->ply = stack->ply + 1;
 
     // TT Lookup
     bool ttHit = false;
@@ -272,7 +267,7 @@ movesLoopQsearch:
     int moveCount = 0;
     while ((move = movegen.nextMove()) != MOVE_NONE) {
 
-        if (   bestValue >= -EVAL_MATE_IN_MAX_PLY
+        if (bestValue >= -EVAL_MATE_IN_MAX_PLY
             && futilityValue > -EVAL_INFINITE
             && futilityValue <= alpha
             && !SEE(board, move, 1)
@@ -305,7 +300,7 @@ movesLoopQsearch:
                 alpha = value;
 
                 if (pvNode)
-                    updatePv(stack->pv, move, (stack + 1)->pv);
+                    updatePv(stack, move);
 
                 if (bestValue >= beta)
                     break;
@@ -335,6 +330,8 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     assert(!(pvNode && cutNode));
     assert(pvNode || alpha == beta - 1);
 
+    if (pvNode)
+        stack->pvLength = stack->ply;
     thread->searchData.selDepth = std::max(stack->ply, thread->searchData.selDepth);
 
     if (!rootNode && alpha < 0 && hasUpcomingRepetition(board, stack->ply)) {
@@ -346,19 +343,12 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     if (depth <= 0) return qsearch<nodeType>(board, thread, stack, alpha, beta);
 
     BoardStack boardStack;
-    Move pv[MAX_PLY + 1] = { MOVE_NONE };
     Move bestMove = MOVE_NONE;
     Move excludedMove = stack->excludedMove;
     Eval bestValue = -EVAL_INFINITE;
     Eval oldAlpha = alpha;
     bool improving = false, skipQuiets = false, excluded = excludedMove != MOVE_NONE;
 
-    Move quietMoves[MAX_MOVES] = { MOVE_NONE };
-    Move captureMoves[MAX_MOVES] = { MOVE_NONE };
-    int quietMoveCount = 0;
-    int captureMoveCount = 0;
-
-    (stack + 1)->ply = stack->ply + 1;
     (stack + 1)->killers[0] = (stack + 1)->killers[1] = MOVE_NONE;
     (stack + 1)->excludedMove = MOVE_NONE;
     (stack + 1)->doubleExtensions = stack->doubleExtensions;
@@ -428,10 +418,10 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
         depth--;
 
     // Improving
-    if (stack->ply >= 2 && (stack - 2)->staticEval != EVAL_NONE) {
+    if ((stack - 2)->staticEval != EVAL_NONE) {
         improving = stack->staticEval > (stack - 2)->staticEval;
     }
-    else if (stack->ply >= 4 && (stack - 4)->staticEval != EVAL_NONE) {
+    else if ((stack - 4)->staticEval != EVAL_NONE) {
         improving = stack->staticEval > (stack - 4)->staticEval;
     }
     else {
@@ -453,15 +443,14 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     if (!pvNode
         && eval >= stack->staticEval
         && eval >= beta
-        && stack->ply
-        && (stack - 1)->move != MOVE_NULL
-        && (stack - 1)->move != MOVE_NONE
+        && (stack - 1)->movedPiece != NO_PIECE
         && depth >= 3
         && !board->stack->checkers
         && stack->ply >= thread->searchData.nmpPlies
         && hasNonPawns(board)
         ) {
         stack->move = MOVE_NULL;
+        stack->movedPiece = NO_PIECE;
         int R = nmpRedBase + depth / nmpDepthDiv + std::min((eval - beta) / nmpDivisor, nmpMin);
 
         doNullMove(board, &boardStack);
@@ -490,6 +479,12 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     assert(board->stack);
 
 movesLoop:
+
+    Move quietMoves[64] = { MOVE_NONE };
+    Move captureMoves[64] = { MOVE_NONE };
+    int quietMoveCount = 0;
+    int captureMoveCount = 0;
+
     // Moves loop
     MoveGen movegen(board, &thread->history, stack, ttMove, stack->killers, depth);
     Move move;
@@ -576,15 +571,16 @@ movesLoop:
         uint64_t newHash = hashAfter(board, move);
         TT.prefetch(newHash);
 
+        if (!capture) {
+            if (quietMoveCount < 64)
+                quietMoves[quietMoveCount++] = move;
+        }
+        else {
+            if (captureMoveCount < 64)
+                captureMoves[captureMoveCount++] = move;
+        }
+
         // Some setup stuff
-        if (pvNode)
-            (stack + 1)->pv = nullptr;
-
-        if (!capture)
-            quietMoves[quietMoveCount++] = move;
-        else
-            captureMoves[captureMoveCount++] = move;
-
         moveCount++;
         thread->searchData.nodesSearched++;
         stack->move = move;
@@ -631,9 +627,6 @@ movesLoop:
 
         // PV moves will be researched at full depth if good enough
         if (pvNode && (moveCount == 1 || value > alpha)) {
-            // Set up pv for the next search
-            (stack + 1)->pv = pv;
-            (stack + 1)->pv[0] = MOVE_NONE;
             value = -search<PV_NODE>(board, stack + 1, thread, newDepth, -beta, -alpha, false);
         }
 
@@ -651,7 +644,7 @@ movesLoop:
                 alpha = value;
 
                 if (pvNode)
-                    updatePv(stack->pv, move, (stack + 1)->pv);
+                    updatePv(stack, move);
 
                 if (bestValue >= beta) {
                     if (!capture) {
@@ -663,7 +656,7 @@ movesLoop:
                         }
 
                         // Update counter move
-                        if (stack->ply >= 1)
+                        if (stack->ply > 0)
                             thread->history.setCounterMove((stack - 1)->move, move);
 
                         int bonus = std::min(historyBonusFactor * (depth + 1) * (depth + 1), historyBonusMax);
@@ -717,26 +710,30 @@ void Thread::tsearch() {
     if (mainThread)
         initTimeManagement(&rootBoard, searchParameters, &searchData);
 
-    // Necessary for aspiration windows
     Eval previousValue = EVAL_NONE;
-
-    std::vector<Move> pvVec;
     bool finishedDepth = false;
+
+    constexpr int STACK_OVERHEAD = 4;
+    SearchStack stackList[MAX_PLY + STACK_OVERHEAD];
+    SearchStack* stack = &stackList[STACK_OVERHEAD];
 
     for (int depth = 1; depth <= maxDepth; depth++) {
         finishedDepth = false;
 
-        SearchStack stackList[MAX_PLY + 4];
-        SearchStack* stack = &stackList[4];
-        Move pv[MAX_PLY + 1];
-        pv[0] = MOVE_NONE;
-        stack->pv = pv;
-        stack->ply = 0;
-        stack->move = MOVE_NONE;
-        stack->movedPiece = NO_PIECE;
-        stack->killers[0] = stack->killers[1] = MOVE_NONE;
-        stack->excludedMove = MOVE_NONE;
-        stack->doubleExtensions = 0;
+        for (int i = 0; i < MAX_PLY + STACK_OVERHEAD; i++) {
+            stackList[i].pvLength = 0;
+            stackList[i].ply = i - STACK_OVERHEAD;
+            stackList[i].staticEval = EVAL_NONE;
+            stackList[i].excludedMove = MOVE_NONE;
+            stackList[i].killers[0] = MOVE_NONE;
+            stackList[i].killers[1] = MOVE_NONE;
+            stackList[i].doubleExtensions = 0;
+            if (i <= STACK_OVERHEAD) {
+                stackList[i].movedPiece = NO_PIECE;
+                stackList[i].move = MOVE_NONE;
+            }
+        }
+
         searchData.rootDepth = depth;
         searchData.selDepth = 0;
 
@@ -810,12 +807,8 @@ void Thread::tsearch() {
             std::cout << "info depth " << depth << " seldepth " << searchData.selDepth << " score " << formatEval(value) << " nodes " << nodes << " time " << ms << " nps " << nps << " pv ";
 
             // Send PV
-            Move move;
-            pvVec.clear();
-            while ((move = *stack->pv++) != MOVE_NONE) {
-                std::cout << moveToString(move) << " ";
-                pvVec.push_back(move);
-            }
+            for (int i = 0; i < stack->pvLength; i++)
+                std::cout << moveToString(stack->pv[i]) << " ";
             std::cout << std::endl;
 
             // Every thread can request a time stop when a depth is cleared
@@ -835,8 +828,8 @@ void Thread::tsearch() {
             int64_t nps = ms == 0 ? 0 : nodes / ((double)ms / 1000);
             std::cout << "info depth " << result.depth << " seldepth " << result.selDepth << " score " << formatEval(result.value) << " nodes " << nodes << " time " << ms << " nps " << nps << " pv ";
 
-            for (Move move : pvVec)
-                std::cout << moveToString(move) << " ";
+            for (int i = 0; i < stack->pvLength; i++)
+                std::cout << moveToString(stack->pv[i]) << " ";
             std::cout << std::endl;
         }
 

--- a/src/types.h
+++ b/src/types.h
@@ -44,7 +44,9 @@ inline Square popLSB(Bitboard* bb) {
 }
 
 struct SearchStack {
-    Move* pv;
+    int pvLength;
+    Move pv[MAX_PLY + 1];
+
     int ply;
 
     Eval staticEval;


### PR DESCRIPTION
Measures a 5-6% speedup and easily passes a non-regression SPRT.
```
Elo   | 3.18 +- 4.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13558 W: 3328 L: 3204 D: 7026
Penta | [82, 1473, 3560, 1567, 97]
https://openbench.yoshie2000.de/test/478/
```

Bench: 2556703