### PR TITLE
Allow some pruning in excluded searches. Bench: 4328439

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -395,11 +395,13 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
         return ttValue;
 
     Eval eval = EVAL_NONE, unadjustedEval = EVAL_NONE;
-    if (board->stack->checkers || excluded) {
+    if (board->stack->checkers) {
         stack->staticEval = EVAL_NONE;
         goto movesLoop;
+    } else if (excluded) {
+        unadjustedEval = eval = stack->staticEval;
     }
-    if (ttHit) {
+    else if (ttHit) {
         unadjustedEval = ttEval != EVAL_NONE ? ttEval : evaluate(board, &thread->nnue);
         eval = stack->staticEval = thread->history.correctStaticEval(unadjustedEval, board);
 
@@ -443,6 +445,7 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     if (!pvNode
         && eval >= stack->staticEval
         && eval >= beta
+        && !excluded
         && (stack - 1)->movedPiece != NO_PIECE
         && depth >= 3
         && !board->stack->checkers


### PR DESCRIPTION
STC
```
Elo   | -5.18 +- 6.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4562 W: 1050 L: 1118 D: 2394
Penta | [40, 578, 1099, 538, 26]
https://openbench.yoshie2000.de/test/515/
```

LTC
```
Elo   | 4.17 +- 3.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.50, 5.50]
Games | N: 12674 W: 2829 L: 2677 D: 7168
Penta | [18, 1372, 3405, 1524, 18]
https://openbench.yoshie2000.de/test/516/
```