### PR TITLE
Make bonus linearly dependent on depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -629,7 +629,7 @@ movesLoop:
                 value = -search<NON_PV_NODE>(board, stack + 1, thread, newDepth, -(alpha + 1), -alpha, !cutNode);
 
                 if (!capture) {
-                    int bonus = std::min(lmrPassBonusFactor * (depth + 1) * (depth + 1), lmrPassBonusMax);
+                    int bonus = std::min(110 * depth, lmrPassBonusMax);
                     thread->history.updateContinuationHistory(board, stack, move, bonus);
                 }
             }
@@ -672,10 +672,10 @@ movesLoop:
                         if (stack->ply > 0)
                             thread->history.setCounterMove((stack - 1)->move, move);
 
-                        int bonus = std::min(historyBonusFactor * (depth + 1) * (depth + 1), historyBonusMax);
+                        int bonus = std::min(160 * depth, historyBonusMax);
                         thread->history.updateQuietHistories(board, stack, move, bonus, quietMoves, quietMoveCount);
                     }
-                    int bonus = std::min(historyBonusFactor * (depth + 1) * (depth + 1), historyBonusMax);
+                    int bonus = std::min(160 * depth, historyBonusMax);
                     thread->history.updateCaptureHistory(board, move, bonus, captureMoves, captureMoveCount);
                     break;
                 }


### PR DESCRIPTION
```
Elo   | 5.51 +- 4.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9404 W: 2238 L: 2089 D: 5077
Penta | [52, 1105, 2267, 1198, 80]
https://openbench.yoshie2000.de/test/575/
```

Bench: 4395935