### PR TITLE
Increase depth for small depths in double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,6 +579,7 @@ movesLoop:
                 if (!pvNode && singularValue + doubleExtensionMargin < singularBeta && stack->doubleExtensions <= doubleExtensionLimit) {
                     extension = 2;
                     stack->doubleExtensions = (stack - 1)->doubleExtensions + 1;
+                    depth += depth < 10;
                 }
             }
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node


### PR DESCRIPTION
STC
```
Elo   | 0.29 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27770 W: 6484 L: 6461 D: 14825
Penta | [195, 3343, 6762, 3414, 171]
https://openbench.yoshie2000.de/test/651/
```

LTC
```
Elo   | 4.15 +- 3.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.50, 5.50]
Games | N: 13068 W: 2935 L: 2779 D: 7354
Penta | [24, 1441, 3446, 1601, 22]
https://openbench.yoshie2000.de/test/652/
```

Bench: 4263384