### PR TITLE
Introducing MultiPV

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -13,11 +13,15 @@
 #include "nnue.h"
 #include "tt.h"
 
-struct ThreadResult {
-    Move move;
+struct RootMove {
     Eval value;
     int depth;
     int selDepth;
+    std::vector<Move> pv;
+};
+
+struct ThreadResult {
+    std::vector<RootMove> rootMoves;
     bool finished;
 };
 
@@ -51,6 +55,7 @@ public:
 
     ThreadResult result;
     std::map<Move, uint64_t> rootMoveNodes;
+    std::vector<Move> excludedRootMoves;
 
     Thread(ThreadPool* threadPool, int threadId);
 
@@ -101,9 +106,10 @@ public:
         searchParameters = std::move(parameters);
 
         for (auto& thread : threads) {
-            thread.get()->result = { MOVE_NONE, EVAL_NONE, 0, 0, false };
+            thread.get()->result.rootMoves.clear();
+            thread.get()->result.finished = false;
         }
-        
+
         for (auto& thread : threads) {
             thread.get()->searching = true;
             thread.get()->cv.notify_all();

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,3 +1,78 @@
 #pragma once
 
+#include <tuple>
+
+template<int... Is>
+struct seq { };
+
+template<int N, int... Is>
+struct gen_seq : gen_seq<N - 1, N - 1, Is...> { };
+
+template<int... Is>
+struct gen_seq<0, Is...> : seq<Is...> { };
+
+template<typename T, typename Func, int... Is>
+void for_each(T&& t, Func f, seq<Is...>) {
+    auto l __attribute((unused)) = { (f(std::get<Is>(t)), 0)... };
+}
+
+template<typename... Ts, typename Func>
+void for_each_in_tuple(std::tuple<Ts...> const& t, Func f) {
+    for_each(t, f, gen_seq<sizeof...(Ts)>());
+}
+
+namespace UCI {
+
+    enum UCIOptionType {
+        UCI_SPIN,
+        UCI_STRING,
+        UCI_CHECK
+    };
+
+    template <UCIOptionType OptionType>
+    struct UCIOption {};
+
+    template <>
+    struct UCIOption<UCI_SPIN> {
+        std::string name;
+        int defaultValue;
+        int value;
+        int minValue;
+        int maxValue;
+    };
+
+    template <>
+    struct UCIOption<UCI_STRING> {
+        std::string name;
+        std::string defaultValue;
+        std::string value;
+    };
+
+    template <>
+    struct UCIOption<UCI_CHECK> {
+        std::string name;
+        bool defaultValue;
+        bool value;
+    };
+
+    struct UCIOptions {
+        UCIOption<UCI_SPIN> multiPV = {
+            "MultiPV",
+            1,
+            1,
+            1,
+            218
+        };
+
+        template <typename Func>
+        void forEach(Func&& f) {
+            auto optionsTuple = std::make_tuple(&multiPV);
+            for_each_in_tuple(optionsTuple, f);
+        }
+    };
+
+    extern UCIOptions Options;
+
+}
+
 void uciLoop(int argc, char* argv[]);


### PR DESCRIPTION
SMP performance is not affected by this patch:
```
Elo   | 147.87 +- 44.02 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=64MB
LLR   | 0.77 (-2.25, 2.89) [0.00, 5.00]
Games | N: 122 W: 54 L: 5 D: 63
Penta | [0, 0, 17, 39, 5]
https://openbench.yoshie2000.de/test/707/
```

MultiPV 4 vs. MultiPV 1
```
Elo   | -196.90 +- 18.19 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 1004 W: 60 L: 575 D: 369
Penta | [120, 284, 90, 7, 1]
https://openbench.yoshie2000.de/test/708/
```

Non-regression barely failed, I blame this on very slight extra overhead that's not really avoidable.
```
Elo   | -2.68 +- 3.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.29 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 14236 W: 3242 L: 3352 D: 7642
Penta | [71, 1547, 3990, 1441, 69]
https://openbench.yoshie2000.de/test/706/
```

Bench: 4194626