### PR TITLE
Add support for (D)FRC

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -33,10 +33,10 @@ const Bitboard RANK_7 = 0x00FF000000000000;
 const Bitboard RANK_8 = 0xFF00000000000000;
 
 void startpos(Board* result) {
-    parseFen(result, "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    parseFen(result, "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", false);
 }
 
-size_t parseFen(Board* board, std::string fen) {
+size_t parseFen(Board* board, std::string fen, bool chess960) {
     Square currentSquare = 56;
     uint8_t currentRank = 7;
     size_t i = 0;
@@ -186,6 +186,7 @@ size_t parseFen(Board* board, std::string fen) {
 
     // Castling
     board->stack->castling = 0;
+    board->castlingSquares[0] = board->castlingSquares[1] = board->castlingSquares[2] = board->castlingSquares[3] = NO_SQUARE;
     for (; i < fen.length(); i++) {
         char c = fen.at(i);
 
@@ -201,18 +202,53 @@ size_t parseFen(Board* board, std::string fen) {
         switch (c) {
         case 'k':
             board->stack->castling |= 0x4;
+            board->castlingSquares[2] = lsb(RANK_8 & FILE_H);
             break;
         case 'K':
             board->stack->castling |= 0x1;
+            board->castlingSquares[0] = lsb(RANK_1 & FILE_H);
             break;
         case 'q':
             board->stack->castling |= 0x8;
+            board->castlingSquares[3] = lsb(RANK_8 & FILE_A);
             break;
         case 'Q':
             board->stack->castling |= 0x2;
+            board->castlingSquares[1] = lsb(RANK_1 & FILE_A);
             break;
         case ' ':
         default:
+            // Chess960 castling
+            if (c >= 'A' && c <= 'H') {
+                // White
+                Square king = lsb(board->byColor[COLOR_WHITE] & board->byPiece[PIECE_KING]);
+                int rookFile = (int)(c - 'A');
+                int kingFile = (int)(king % 8);
+                if (rookFile > kingFile) {
+                    board->stack->castling |= 0x1;
+                    board->castlingSquares[0] = (Square)rookFile;
+                }
+                else {
+                    board->stack->castling |= 0x2;
+                    board->castlingSquares[1] = (Square)rookFile;
+                }
+                break;
+            }
+            else if (c >= 'a' && c <= 'h') {
+                // Black
+                Square king = lsb(board->byColor[COLOR_BLACK] & board->byPiece[PIECE_KING]);
+                int rookFile = (int)(c - 'a');
+                int kingFile = (int)(king % 8);
+                if (rookFile > kingFile) {
+                    board->stack->castling |= 0x4;
+                    board->castlingSquares[2] = (Square)(56 + rookFile);
+                }
+                else {
+                    board->stack->castling |= 0x8;
+                    board->castlingSquares[3] = (Square)(56 + rookFile);
+                }
+                break;
+            }
             std::cout << "Weird char in fen castling: " << c << " (index " << i << ")" << std::endl;
             exit(-1);
             break;
@@ -283,35 +319,50 @@ size_t parseFen(Board* board, std::string fen) {
     updateSliderPins(board, COLOR_WHITE);
     updateSliderPins(board, COLOR_BLACK);
 
+    board->chess960 = chess960;
+
     return i;
 }
 
-void castlingRookSquares(Board* board, Square origin, Square target, Square* rookOrigin, Square* rookTarget, uint8_t* castling) {
+void castlingSquares(Board* board, Square origin, Square* target, Square* rookOrigin, Square* rookTarget, uint8_t* castling) {
     if (board->stm == COLOR_WHITE) {
-        if (target > origin) { // Kingside White
-            *rookOrigin = 7;
+        if (*target > origin) { // Kingside White
+            *rookOrigin = board->castlingSquares[0];
             *rookTarget = 5;
+            *target = 6;
         }
         else { // Queenside White
-            *rookOrigin = 0;
+            *rookOrigin = board->castlingSquares[1];
             *rookTarget = 3;
+            *target = 2;
         }
         *castling &= 0xC; // Clear flags for white
     }
     else {
-        if (target > origin) { // Kingside Black
-            *rookOrigin = 63;
+        if (*target > origin) { // Kingside Black
+            *rookOrigin = board->castlingSquares[2];
             *rookTarget = 61;
+            *target = 62;
         }
         else { // Queenside Black
-            *rookOrigin = 56;
+            *rookOrigin = board->castlingSquares[3];
             *rookTarget = 59;
+            *target = 58;
         }
         *castling &= 0x3; // Clear flags for black
     }
 }
 
+constexpr void movePiece(Board* board, Piece piece, Square origin, Square target, Bitboard fromTo) {
+    board->byColor[board->stm] ^= fromTo;
+    board->byPiece[piece] ^= fromTo;
+
+    board->pieces[origin] = NO_PIECE;
+    board->pieces[target] = piece;
+}
+
 void doMove(Board* board, BoardStack* newStack, Move move, uint64_t newHash, NNUE* nnue) {
+    // General setup stuff
     newStack->previous = board->stack;
     board->stack = newStack;
     memcpy(newStack->pieceCount, newStack->previous->pieceCount, sizeof(int) * 12 + sizeof(uint8_t));
@@ -321,6 +372,9 @@ void doMove(Board* board, BoardStack* newStack, Move move, uint64_t newHash, NNU
     newStack->rule50_ply = newStack->previous->rule50_ply + 1;
     newStack->nullmove_ply = newStack->previous->nullmove_ply + 1;
 
+    nnue->incrementAccumulator();
+
+    // Calculate general information about the move
     Square origin = moveOrigin(move);
     Square target = moveTarget(move);
     Move specialMove = move & 0x3000;
@@ -328,6 +382,7 @@ void doMove(Board* board, BoardStack* newStack, Move move, uint64_t newHash, NNU
     assert(origin < 64 && target < 64);
 
     newStack->capturedPiece = board->pieces[target];
+    newStack->enpassantTarget = 0;
     Square captureTarget = target;
     Bitboard captureTargetBB = C64(1) << captureTarget;
 
@@ -338,82 +393,43 @@ void doMove(Board* board, BoardStack* newStack, Move move, uint64_t newHash, NNU
     Bitboard targetBB = C64(1) << target;
     Bitboard fromTo = originBB | targetBB;
 
-    board->byColor[board->stm] ^= fromTo;
-    board->byPiece[piece] ^= fromTo;
-
-    board->pieces[origin] = NO_PIECE;
-    board->pieces[target] = piece;
-
-    // Increment the NNUE accumulator to indicate that we're on a different move now
-    nnue->incrementAccumulator();
-
-    newStack->enpassantTarget = 0;
-
-    if (piece == PIECE_PAWN) {
+    switch (specialMove) {
+    case MOVE_PROMOTION:
+        movePiece(board, piece, origin, target, fromTo);
         newStack->rule50_ply = 0;
 
-        // This move is en passent
-        if (specialMove == MOVE_ENPASSANT) {
-            newStack->capturedPiece = PIECE_PAWN;
-            captureTarget = target - UP[board->stm];
+        newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][origin];
 
-            assert(captureTarget < 64);
+        if (newStack->capturedPiece != NO_PIECE) {
+            board->byColor[1 - board->stm] ^= captureTargetBB; // take away the captured piece
+            board->byPiece[newStack->capturedPiece] ^= captureTargetBB;
 
-            captureTargetBB = C64(1) << captureTarget;
-            board->pieces[captureTarget] = NO_PIECE; // remove the captured pawn
+            nnue->removePiece(captureTarget, newStack->capturedPiece, (Color)(1 - board->stm));
 
-            newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[1 - board->stm][PIECE_PAWN][captureTarget];
+            newStack->pieceCount[1 - board->stm][newStack->capturedPiece]--;
+
+            if (newStack->capturedPiece == PIECE_ROOK) {
+                Square rookSquare = piece == PIECE_ROOK ? origin : captureTarget;
+                if (rookSquare == board->castlingSquares[0]) {
+                    newStack->castling &= ~0x1; // Kingside castle white
+                }
+                else if (rookSquare == board->castlingSquares[1]) {
+                    newStack->castling &= ~0x2; // Queenside castle white
+                }
+                else if (rookSquare == board->castlingSquares[2]) {
+                    newStack->castling &= ~0x4; // Kingside castle black
+                }
+                else if (rookSquare == board->castlingSquares[3]) {
+                    newStack->castling &= ~0x8; // Queenside castle black
+                }
+            }
         }
 
-
-        if ((origin ^ target) == 16) {
-            assert(target - UP[board->stm] < 64);
-
-            Bitboard enemyPawns = board->byColor[1 - board->stm] & board->byPiece[PIECE_PAWN];
-            Bitboard epRank = board->stm == COLOR_WHITE ? RANK_4 : RANK_5;
-            Bitboard epPawns = ((C64(1) << (target + 1)) | (C64(1) << (target - 1))) & epRank & enemyPawns;
-            if (epPawns)
-                newStack->enpassantTarget = C64(1) << (target - UP[board->stm]);
-
-        }
-
-        newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][target];
-    }
-
-    // Handle capture
-    if (newStack->capturedPiece != NO_PIECE) {
-        board->byColor[1 - board->stm] ^= captureTargetBB; // take away the captured piece
-        board->byPiece[newStack->capturedPiece] ^= captureTargetBB;
-
-        nnue->removePiece(captureTarget, newStack->capturedPiece, (Color)(1 - board->stm));
-
-        newStack->pieceCount[1 - board->stm][newStack->capturedPiece]--;
-        newStack->rule50_ply = 0;
-    }
-
-    // This move is castling
-    if (specialMove == MOVE_CASTLING) {
-        Square rookOrigin, rookTarget;
-        castlingRookSquares(board, origin, target, &rookOrigin, &rookTarget, &newStack->castling);
-        assert(rookOrigin < 64 && rookTarget < 64);
-
-        Bitboard rookFromToBB = (C64(1) << rookOrigin) | (C64(1) << rookTarget);
-        board->pieces[rookOrigin] = NO_PIECE;
-        board->pieces[rookTarget] = PIECE_ROOK;
-        board->byColor[board->stm] ^= rookFromToBB;
-        board->byPiece[PIECE_ROOK] ^= rookFromToBB;
-
-        nnue->movePiece(rookOrigin, rookTarget, PIECE_ROOK, board->stm);
-    }
-
-    // This move is promotion
-    if (specialMove == MOVE_PROMOTION) {
         promotionPiece = PROMOTION_PIECE[move >> 14];
         board->byPiece[piece] ^= targetBB;
         board->byPiece[promotionPiece] ^= targetBB;
 
         board->pieces[target] = promotionPiece;
-        newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][target];
 
         // Promotion, we don't move the current piece, instead we remove it from the origin square
         // and place the promotionPiece on the target square. This saves one accumulator update
@@ -422,41 +438,118 @@ void doMove(Board* board, BoardStack* newStack, Move move, uint64_t newHash, NNU
 
         newStack->pieceCount[board->stm][PIECE_PAWN]--;
         newStack->pieceCount[board->stm][promotionPiece]++;
-        newStack->rule50_ply = 0;
-    }
-    else {
-        // No promotion, we can normally move the piece in the accumulator
-        nnue->movePiece(origin, target, piece, board->stm);
-    }
 
-    // Unset castling flags if necessary
-    if (piece == PIECE_KING) {
-        if (board->stm == COLOR_WHITE)
-            newStack->castling &= 0xC;
-        else
-            newStack->castling &= 0x3;
+        break;
+
+    case MOVE_CASTLING: {
+        Square rookOrigin, rookTarget;
+        castlingSquares(board, origin, &target, &rookOrigin, &rookTarget, &newStack->castling);
+        assert(rookOrigin < 64 && rookTarget < 64 && target < 64);
+
+        Bitboard rookFromToBB = (C64(1) << rookOrigin) ^ (C64(1) << rookTarget);
+        targetBB = C64(1) << target;
+        fromTo = originBB ^ targetBB;
+
+        board->pieces[rookOrigin] = NO_PIECE;
+        board->pieces[origin] = NO_PIECE;
+        board->pieces[rookTarget] = PIECE_ROOK;
+        board->pieces[target] = PIECE_KING;
+        board->byColor[board->stm] ^= rookFromToBB ^ fromTo;
+        board->byPiece[PIECE_ROOK] ^= rookFromToBB;
+        board->byPiece[PIECE_KING] ^= fromTo;
+
+        nnue->movePiece(origin, target, PIECE_KING, board->stm);
+        nnue->movePiece(rookOrigin, rookTarget, PIECE_ROOK, board->stm);
+
+        newStack->capturedPiece = NO_PIECE;
     }
-    if (piece == PIECE_ROOK || newStack->capturedPiece == PIECE_ROOK) {
-        switch (piece == PIECE_ROOK ? origin : captureTarget) {
-        case 0:
-            newStack->castling &= ~0x2; // Queenside castle white
-            break;
-        case 7:
-            newStack->castling &= ~0x1; // Kingside castle white
-            break;
-        case 56:
-            newStack->castling &= ~0x8; // Queenside castle black
-            break;
-        case 63:
-            newStack->castling &= ~0x4; // Kingside castle black
-            break;
-        default:
-            break;
+                      break;
+
+    case MOVE_ENPASSANT:
+        movePiece(board, piece, origin, target, fromTo);
+        nnue->movePiece(origin, target, piece, board->stm);
+        newStack->rule50_ply = 0;
+
+        captureTarget = target - UP[board->stm];
+        newStack->capturedPiece = PIECE_PAWN;
+
+        assert(captureTarget < 64);
+
+        captureTargetBB = C64(1) << captureTarget;
+        board->pieces[captureTarget] = NO_PIECE; // remove the captured pawn
+
+        newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][target] ^ ZOBRIST_PIECE_SQUARES[1 - board->stm][PIECE_PAWN][captureTarget];
+
+        board->byColor[1 - board->stm] ^= captureTargetBB; // take away the captured piece
+        board->byPiece[PIECE_PAWN] ^= captureTargetBB;
+
+        nnue->removePiece(captureTarget, PIECE_PAWN, (Color)(1 - board->stm));
+
+        newStack->pieceCount[1 - board->stm][PIECE_PAWN]--;
+
+        break;
+
+    default: // Normal moves
+        movePiece(board, piece, origin, target, fromTo);
+        nnue->movePiece(origin, target, piece, board->stm);
+
+        if (piece == PIECE_PAWN) {
+            // Double push
+            if ((origin ^ target) == 16) {
+                assert(target - UP[board->stm] < 64);
+
+                Bitboard enemyPawns = board->byColor[1 - board->stm] & board->byPiece[PIECE_PAWN];
+                Bitboard epRank = board->stm == COLOR_WHITE ? RANK_4 : RANK_5;
+                Bitboard epPawns = ((C64(1) << (target + 1)) | (C64(1) << (target - 1))) & epRank & enemyPawns;
+                if (epPawns)
+                    newStack->enpassantTarget = C64(1) << (target - UP[board->stm]);
+
+            }
+
+            newStack->rule50_ply = 0;
+            newStack->pawnHash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][PIECE_PAWN][target];
         }
+
+        if (newStack->capturedPiece != NO_PIECE) {
+            board->byColor[1 - board->stm] ^= captureTargetBB; // take away the captured piece
+            board->byPiece[newStack->capturedPiece] ^= captureTargetBB;
+
+            nnue->removePiece(captureTarget, newStack->capturedPiece, (Color)(1 - board->stm));
+
+            newStack->pieceCount[1 - board->stm][newStack->capturedPiece]--;
+            newStack->rule50_ply = 0;
+        }
+
+        // Unset castling flags if necessary
+        if (piece == PIECE_KING) {
+            if (board->stm == COLOR_WHITE) {
+                newStack->castling &= 0xC;
+            }
+            else {
+                newStack->castling &= 0x3;
+            }
+        }
+        if (piece == PIECE_ROOK || newStack->capturedPiece == PIECE_ROOK) {
+            Square rookSquare = piece == PIECE_ROOK ? origin : captureTarget;
+            if (rookSquare == board->castlingSquares[0]) {
+                newStack->castling &= ~0x1; // Kingside castle white
+            }
+            else if (rookSquare == board->castlingSquares[1]) {
+                newStack->castling &= ~0x2; // Queenside castle white
+            }
+            else if (rookSquare == board->castlingSquares[2]) {
+                newStack->castling &= ~0x4; // Kingside castle black
+            }
+            else if (rookSquare == board->castlingSquares[3]) {
+                newStack->castling &= ~0x8; // Queenside castle black
+            }
+        }
+        break;
     }
 
     // Update king checking stuff
     assert((board->byColor[1 - board->stm] & board->byPiece[PIECE_KING]) > 0);
+    assert((board->byColor[board->stm] & board->byPiece[PIECE_KING]) > 0);
 
     Square enemyKing = lsb(board->byColor[1 - board->stm] & board->byPiece[PIECE_KING]);
     newStack->checkers = attackersTo(board, enemyKing, board->byColor[COLOR_WHITE] | board->byColor[COLOR_BLACK]) & board->byColor[board->stm];
@@ -474,25 +567,45 @@ void undoMove(Board* board, Move move, NNUE* nnue) {
     Square origin = moveOrigin(move);
     Square target = moveTarget(move);
     Square captureTarget = target;
+    Bitboard captureTargetBB = C64(1) << captureTarget;
 
     assert(origin < 64 && target < 64);
 
     Bitboard originBB = C64(1) << origin;
     Bitboard targetBB = C64(1) << target;
     Bitboard fromTo = originBB | targetBB;
-    Bitboard captureTargetBB = C64(1) << captureTarget;
-
-    board->byColor[board->stm] ^= fromTo;
 
     Piece piece = board->pieces[target];
+    Move specialMove = move & 0x3000;
 
-    board->byPiece[piece] ^= fromTo;
+    // Castling
+    if (specialMove == MOVE_CASTLING) {
+        Square rookOrigin, rookTarget;
+        castlingSquares(board, origin, &target, &rookOrigin, &rookTarget, &board->stack->castling);
 
-    board->pieces[target] = NO_PIECE;
-    board->pieces[origin] = piece;
+        assert(rookOrigin < 64 && rookTarget < 64 && target < 64);
+
+        Bitboard rookFromToBB = (C64(1) << rookOrigin) ^ (C64(1) << rookTarget);
+        targetBB = C64(1) << target;
+        fromTo = originBB ^ targetBB;
+
+        board->pieces[rookTarget] = NO_PIECE;
+        board->pieces[target] = NO_PIECE;
+        board->pieces[rookOrigin] = PIECE_ROOK;
+        board->pieces[origin] = PIECE_KING;
+        board->byColor[board->stm] ^= rookFromToBB ^ fromTo;
+        board->byPiece[PIECE_ROOK] ^= rookFromToBB;
+        board->byPiece[PIECE_KING] ^= fromTo;
+    }
+    else {
+        board->byColor[board->stm] ^= fromTo;
+        board->byPiece[piece] ^= fromTo;
+
+        board->pieces[target] = NO_PIECE;
+        board->pieces[origin] = piece;
+    }
 
     // This move is en passent
-    Move specialMove = move & 0x3000;
     if (specialMove == MOVE_ENPASSANT) {
         captureTarget = target - UP[board->stm];
 
@@ -502,24 +615,10 @@ void undoMove(Board* board, Move move, NNUE* nnue) {
     }
 
     // Handle capture
-    if (board->stack->capturedPiece != NO_PIECE) {
+    if (board->stack->capturedPiece != NO_PIECE && specialMove != MOVE_CASTLING) {
         board->pieces[captureTarget] = board->stack->capturedPiece;
         board->byColor[1 - board->stm] ^= captureTargetBB;
         board->byPiece[board->stack->capturedPiece] ^= captureTargetBB;
-    }
-
-    // Castling
-    if (specialMove == MOVE_CASTLING) {
-        Square rookOrigin, rookTarget;
-        castlingRookSquares(board, origin, target, &rookOrigin, &rookTarget, &board->stack->castling);
-
-        assert(rookOrigin < 64 && rookTarget < 64);
-
-        Bitboard rookFromToBB = (C64(1) << rookOrigin) | (C64(1) << rookTarget);
-        board->pieces[rookOrigin] = PIECE_ROOK;
-        board->pieces[rookTarget] = NO_PIECE;
-        board->byColor[board->stm] ^= rookFromToBB;
-        board->byPiece[PIECE_ROOK] ^= rookFromToBB;
     }
 
     // This move is promotion
@@ -584,8 +683,6 @@ uint64_t hashAfter(Board* board, Move move) {
 
     uint8_t newCastling = board->stack->castling;
 
-    hash ^= ZOBRIST_PIECE_SQUARES[board->stm][piece][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][piece][target];
-
     if (board->stack->enpassantTarget != 0)
         hash ^= ZOBRIST_ENPASSENT[lsb(board->stack->enpassantTarget) % 8];
 
@@ -611,9 +708,14 @@ uint64_t hashAfter(Board* board, Move move) {
         Square rookOrigin, rookTarget;
 
         hash ^= ZOBRIST_CASTLING[newCastling];
-        castlingRookSquares(board, origin, target, &rookOrigin, &rookTarget, &newCastling);
+        castlingSquares(board, origin, &target, &rookOrigin, &rookTarget, &newCastling);
         hash ^= ZOBRIST_CASTLING[newCastling];
+
+        hash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_KING][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][PIECE_KING][target];
         hash ^= ZOBRIST_PIECE_SQUARES[board->stm][PIECE_ROOK][rookOrigin] ^ ZOBRIST_PIECE_SQUARES[board->stm][PIECE_ROOK][rookTarget];
+    }
+    else {
+        hash ^= ZOBRIST_PIECE_SQUARES[board->stm][piece][origin] ^ ZOBRIST_PIECE_SQUARES[board->stm][piece][target];
     }
 
     if (specialMove == MOVE_PROMOTION) {
@@ -631,21 +733,18 @@ uint64_t hashAfter(Board* board, Move move) {
     }
     if (piece == PIECE_ROOK || capturedPiece == PIECE_ROOK) {
         hash ^= ZOBRIST_CASTLING[newCastling & 0xF];
-        switch (piece == PIECE_ROOK ? origin : captureTarget) {
-        case 0:
-            newCastling &= ~0x2; // Queenside castle white
-            break;
-        case 7:
+        Square rookSquare = piece == PIECE_ROOK ? origin : captureTarget;
+        if (rookSquare == board->castlingSquares[0]) {
             newCastling &= ~0x1; // Kingside castle white
-            break;
-        case 56:
-            newCastling &= ~0x8; // Queenside castle black
-            break;
-        case 63:
+        }
+        else if (rookSquare == board->castlingSquares[1]) {
+            newCastling &= ~0x2; // Queenside castle white
+        }
+        else if (rookSquare == board->castlingSquares[2]) {
             newCastling &= ~0x4; // Kingside castle black
-            break;
-        default:
-            break;
+        }
+        else if (rookSquare == board->castlingSquares[3]) {
+            newCastling &= ~0x8; // Queenside castle black
         }
         hash ^= ZOBRIST_CASTLING[newCastling & 0xF];
     }
@@ -970,8 +1069,10 @@ int validateBoard(Board* board) {
             else if ((board->byColor[COLOR_BLACK] & board->byPiece[PIECE_KING] & mask) != 0)
                 second = 14;
 
-            if (first != second)
+            if (first != second) {
+                std::cout << first << " " << second << std::endl;
                 return idx;
+            }
         }
     }
     return -1;

--- a/src/board.h
+++ b/src/board.h
@@ -31,6 +31,8 @@ struct Board {
 
     Color stm;
     uint8_t ply;
+    bool chess960;
+    Square castlingSquares[4]; // For each castling right, stores the square of the corresponding rook
 
     struct BoardStack* stack;
 };
@@ -61,7 +63,7 @@ struct BoardStack {
 };
 
 void startpos(Board* result);
-size_t parseFen(Board* board, std::string fen);
+size_t parseFen(Board* board, std::string fen, bool chess960);
 
 #include "nnue.h"
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -52,9 +52,12 @@ int History::getContinuationHistory(Board* board, SearchStack* stack, Move move)
     Piece piece = board->pieces[moveOrigin(move)];
     if (piece == NO_PIECE)
         piece = board->pieces[moveTarget(move)];
-    Square target = moveTarget(move);
+    if ((0x3000 & move) == MOVE_CASTLING)
+        piece = PIECE_KING;
 
     assert(piece != NO_PIECE);
+
+    Square target = moveTarget(move);
 
     int score = 0;
 
@@ -75,10 +78,12 @@ void History::updateContinuationHistory(Board* board, SearchStack* stack, Move m
     Piece piece = board->pieces[moveOrigin(move)];
     if (piece == NO_PIECE)
         piece = board->pieces[moveTarget(move)];
-    assert(piece != NO_PIECE);
-    Square target = moveTarget(move);
+    if ((0x3000 & move) == MOVE_CASTLING)
+        piece = PIECE_KING;
 
     assert(piece != NO_PIECE);
+
+    Square target = moveTarget(move);
 
     int16_t scaledBonus = bonus - getContinuationHistory(board, stack, move) * std::abs(bonus) / 32000;
 

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -141,14 +141,15 @@ bool isLegal(Board* board, Move move) {
 
     if (specialMove == MOVE_CASTLING) {
         // Check that none of the important squares (including the current king position!) are being attacked
-        if (target < origin) {
-            for (Square s = board->stm == COLOR_WHITE ? 2 : 58; s <= origin; s++) {
+        Square adjustedTarget = target < origin ? (board->stm == COLOR_WHITE ? 2 : 58) : (board->stm == COLOR_WHITE ? 6 : 62);
+        if (adjustedTarget < origin) {
+            for (Square s = adjustedTarget; s <= origin; s++) {
                 if (board->byColor[1 - board->stm] & attackersTo(board, s, occupied))
                     return false;
             }
         }
         else {
-            for (Square s = board->stm == COLOR_WHITE ? 6 : 62; s >= origin; s--) {
+            for (Square s = adjustedTarget; s >= origin; s--) {
                 if (board->byColor[1 - board->stm] & attackersTo(board, s, occupied))
                     return false;
             }
@@ -810,7 +811,9 @@ Move stringToMove(char* string, Board* board) {
 
     // Figure out whether this is en passent or castling and set the flags accordingly
     if (board != nullptr) {
-        if (board->pieces[origin] == PIECE_KING && std::abs(target - origin) == 2)
+        if (board->chess960 && board->pieces[origin] == PIECE_KING && board->pieces[target] == PIECE_ROOK && !((C64(1) << target) & board->byColor[1 - board->stm]))
+            move |= MOVE_CASTLING;
+        if (!board->chess960 && board->pieces[origin] == PIECE_KING && std::abs(target - origin) == 2)
             move |= MOVE_CASTLING;
         if (board->pieces[origin] == PIECE_PAWN && board->pieces[target] == NO_PIECE && (std::abs(target - origin) == 7 || std::abs(target - origin) == 9))
             move |= MOVE_ENPASSANT;

--- a/src/move.h
+++ b/src/move.h
@@ -144,7 +144,7 @@ void generateLastSqTable();
 
 void generateMoves(Board* board, Move* moves, int* counter, bool onlyCaptures = false);
 
-std::string moveToString(Move move);
+std::string moveToString(Move move, bool chess960);
 
 Square stringToSquare(char* string);
 Move stringToMove(char* string, Board* board = nullptr);

--- a/src/move.h
+++ b/src/move.h
@@ -132,6 +132,7 @@ constexpr Square moveTarget(Move move) {
 
 constexpr bool isCapture(Board* board, Move move) {
     Move moveType = 0x3000 & move;
+    if (moveType == MOVE_CASTLING) return false;
     if (moveType == MOVE_ENPASSANT || (moveType == MOVE_PROMOTION && (move & 0xC000) == PROMOTION_QUEEN)) return true;
     return board->pieces[moveTarget(move)] != NO_PIECE;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -169,7 +169,7 @@ uint64_t perft(Board* board, int depth) {
         uint64_t subNodes = perftInternal(board, &nnue, depth - 1);
         undoMove(board, move, &nnue);
 
-        std::cout << moveToString(move) << ": " << subNodes << std::endl;
+        std::cout << moveToString(move, UCI::Options.chess960.value) << ": " << subNodes << std::endl;
 
         nodes += subNodes;
     }
@@ -874,7 +874,7 @@ void Thread::tsearch() {
 
                 // Send PV
                 for (Move move : rootMove.pv)
-                    std::cout << moveToString(move) << " ";
+                    std::cout << moveToString(move, UCI::Options.chess960.value) << " ";
                 std::cout << std::endl;
             }
 
@@ -908,6 +908,6 @@ bestMoveOutput:
     result.finished = true;
 
     if (mainThread) {
-        std::cout << "bestmove " << moveToString(result.rootMoves[0].pv[0]) << std::endl;
+        std::cout << "bestmove " << moveToString(result.rootMoves[0].pv[0], UCI::Options.chess960.value) << std::endl;
     }
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -81,10 +81,8 @@ const std::vector<std::string> benchPositions = {
       "r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1",
 
       // Chess 960
-    //   "setoption name UCI_Chess960 value true",
-    //   "bbqnnrkr/pppppppp/8/8/8/8/PPPPPPPP/BBQNNRKR w HFhf - 0 1 moves g2g3 d7d5 d2d4 c8h3 c1g5 e8d6 g5e7 f7f6",
-    //   "nqbnrkrb/pppppppp/8/8/8/8/PPPPPPPP/NQBNRKRB w KQkq - 0 1",
-    //   "setoption name UCI_Chess960 value false"
+      "bb1n1rkr/ppp1Q1pp/3n1p2/3p4/3P4/6Pq/PPP1PP1P/BB1NNRKR w HFhf - 0 5",
+      "nqbnrkrb/pppppppp/8/8/8/8/PPPPPPPP/NQBNRKRB w EGeg - 0 1",
 };
 
 const std::vector<std::string> seeTest = {
@@ -186,9 +184,10 @@ void bench(std::deque<BoardStack>* stackQueue, Board* board) {
 
     threads.waitForSearchFinished();
 
+    int i = 0;
     for (const std::string& fen : benchPositions) {
         threads.ucinewgame();
-        parseFen(board, fen);
+        parseFen(board, fen, i++ >= 44);
         SearchParameters parameters;
         parameters.depth = 13;
 
@@ -222,32 +221,47 @@ void perfttest(std::deque<BoardStack>* stackQueue, Board* board) {
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 4865609) std::cout << "Failed perft for startpos" << std::endl;
 
-    parseFen(board, "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    parseFen(board, "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", false);
     threads.startSearching(*board, *stackQueue, parameters);
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 193690690) std::cout << "Failed perft for r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1" << std::endl;
 
-    parseFen(board, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+    parseFen(board, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", false);
     parameters.depth = 6;
     threads.startSearching(*board, *stackQueue, parameters);
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 11030083) std::cout << "Failed perft for 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1" << std::endl;
 
-    parseFen(board, "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1");
+    parseFen(board, "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", false);
     parameters.depth = 5;
     threads.startSearching(*board, *stackQueue, parameters);
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 15833292) std::cout << "Failed perft for r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1" << std::endl;
 
-    parseFen(board, "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8");
+    parseFen(board, "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", false);
     threads.startSearching(*board, *stackQueue, parameters);
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 89941194) std::cout << "Failed perft for rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8" << std::endl;
 
-    parseFen(board, "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10");
+    parseFen(board, "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", false);
     threads.startSearching(*board, *stackQueue, parameters);
     threads.waitForSearchFinished();
     if (threads.nodesSearched() != 164075551) std::cout << "Failed perft for r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10" << std::endl;
+
+    parseFen(board, "1rqbkrbn/1ppppp1p/1n6/p1N3p1/8/2P4P/PP1PPPP1/1RQBKRBN w FBfb - 0 9", true);
+    threads.startSearching(*board, *stackQueue, parameters);
+    threads.waitForSearchFinished();
+    if (threads.nodesSearched() != 8652810) std::cout << "Failed perft for 1rqbkrbn/1ppppp1p/1n6/p1N3p1/8/2P4P/PP1PPPP1/1RQBKRBN w FBfb - 0 9" << std::endl;
+
+    parseFen(board, "rbbqn1kr/pp2p1pp/6n1/2pp1p2/2P4P/P7/BP1PPPP1/R1BQNNKR w HAha - 0 9", true);
+    threads.startSearching(*board, *stackQueue, parameters);
+    threads.waitForSearchFinished();
+    if (threads.nodesSearched() != 26302461) std::cout << "Failed perft for rbbqn1kr/pp2p1pp/6n1/2pp1p2/2P4P/P7/BP1PPPP1/R1BQNNKR w HAha - 0 9" << std::endl;
+
+    parseFen(board, "rqbbknr1/1ppp2pp/p5n1/4pp2/P7/1PP5/1Q1PPPPP/R1BBKNRN w GAga - 0 9", true);
+    threads.startSearching(*board, *stackQueue, parameters);
+    threads.waitForSearchFinished();
+    if (threads.nodesSearched() != 11029596) std::cout << "Failed perft for rqbbknr1/1ppp2pp/p5n1/4pp2/P7/1PP5/1Q1PPPPP/R1BBKNRN w GAga - 0 9" << std::endl;
 
     std::cout << "Perfttest done" << std::endl;
 }
@@ -276,7 +290,7 @@ void seetest(Board* board) {
         int gain = stoi(tokens[2]);
         bool expected = gain >= 0;
 
-        parseFen(board, fen);
+        parseFen(board, fen, false);
         char charMove[6] = { '\0' };
         uciMove.copy(charMove, uciMove.length() - 2, 1);
         Move move = stringToMove(charMove, board);
@@ -285,7 +299,7 @@ void seetest(Board* board) {
         if (result == expected)
             passed++;
         else {
-            std::cout << "FAILED " << fen << "|" << uciMove << "(" << moveToString(move) << ")" << " | Expected: " << expected << std::endl;
+            std::cout << "FAILED " << fen << "|" << uciMove << "(" << moveToString(move, UCI::Options.chess960.value) << ")" << " | Expected: " << expected << std::endl;
             failed++;
         }
 
@@ -306,7 +320,7 @@ void position(std::string line, Board* board, std::deque<BoardStack>* stackQueue
     }
     else if (matchesToken(line, "fen")) {
         line = line.substr(4);
-        size_t fenLength = parseFen(board, line) + 1;
+        size_t fenLength = parseFen(board, line, UCI::Options.chess960.value) + 1;
         if (line.length() > fenLength)
             line = line.substr(fenLength);
     }

--- a/src/uci.h
+++ b/src/uci.h
@@ -64,9 +64,15 @@ namespace UCI {
             218
         };
 
+        UCIOption<UCI_CHECK> chess960 = {
+            "UCI_Chess960",
+            false,
+            false
+        };
+
         template <typename Func>
         void forEach(Func&& f) {
-            auto optionsTuple = std::make_tuple(&multiPV);
+            auto optionsTuple = std::make_tuple(&multiPV, &chess960);
             for_each_in_tuple(optionsTuple, f);
         }
     };


### PR DESCRIPTION
(D)FRC games run without crashes
```
Elo   | 5.52 +- 14.07 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 1008 W: 225 L: 209 D: 574
Penta | [11, 111, 245, 125, 12]
https://openbench.yoshie2000.de/test/725/
```

Non-regression almost passed:
```
Elo   | -1.42 +- 2.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 47950 W: 10947 L: 11143 D: 25860
Penta | [346, 5757, 11886, 5719, 267]
https://openbench.yoshie2000.de/test/726/
```

Bench: 4280561