### PR TITLE
Fix castling square inference when loading fens

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -206,7 +206,7 @@ size_t parseFen(Board* board, std::string fen, bool chess960) {
         case 'k':
             board->stack->castling |= 0x4;
             // Chess960 support: Find black kingside rook
-            rookBB = board->byColor[COLOR_BLACK] & board->byPiece[PIECE_ROOK];
+            rookBB = board->byColor[COLOR_BLACK] & board->byPiece[PIECE_ROOK] & RANK_8;
             rooks.clear();
             while (rookBB) {
                 rooks.push_back(popLSB(&rookBB));
@@ -216,7 +216,7 @@ size_t parseFen(Board* board, std::string fen, bool chess960) {
         case 'K':
             board->stack->castling |= 0x1;
             // Chess960 support: Find white kingside rook
-            rookBB = board->byColor[COLOR_WHITE] & board->byPiece[PIECE_ROOK];
+            rookBB = board->byColor[COLOR_WHITE] & board->byPiece[PIECE_ROOK] & RANK_1;
             rooks.clear();
             while (rookBB) {
                 rooks.push_back(popLSB(&rookBB));
@@ -226,7 +226,7 @@ size_t parseFen(Board* board, std::string fen, bool chess960) {
         case 'q':
             board->stack->castling |= 0x8;
             // Chess960 support: Find black queenside rook
-            rookBB = board->byColor[COLOR_BLACK] & board->byPiece[PIECE_ROOK];
+            rookBB = board->byColor[COLOR_BLACK] & board->byPiece[PIECE_ROOK] & RANK_8;
             rooks.clear();
             while (rookBB) {
                 rooks.push_back(popLSB(&rookBB));
@@ -236,7 +236,7 @@ size_t parseFen(Board* board, std::string fen, bool chess960) {
         case 'Q':
             board->stack->castling |= 0x2;
             // Chess960 support: Find white queenside rook
-            rookBB = board->byColor[COLOR_WHITE] & board->byPiece[PIECE_ROOK];
+            rookBB = board->byColor[COLOR_WHITE] & board->byPiece[PIECE_ROOK] & RANK_1;
             rooks.clear();
             while (rookBB) {
                 rooks.push_back(popLSB(&rookBB));


### PR DESCRIPTION
Non-regression STC without crashes from dev
```
Elo   | 3.94 +- 5.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 7498 W: 1779 L: 1694 D: 4025
Penta | [37, 753, 2084, 838, 37]
https://openbench.yoshie2000.de/test/730/
```

Confirm (D)FRC play without crashes
```
Elo   | 6.56 +- 13.65 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 1006 W: 213 L: 194 D: 599
Penta | [10, 93, 282, 104, 14]
https://openbench.yoshie2000.de/test/731/
```

Bench: 4280561