### PR TITLE
Introduce UCI MoveOverhead option

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 
 #include "time.h"
+#include "uci.h"
 
 int64_t getTime() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -36,7 +37,7 @@ void initTimeManagement(Board* rootBoard, SearchParameters* parameters, SearchDa
     if (time < 0)
         time = 1000;
     // Subtract some time for communication overhead
-    time -= std::min((int64_t)100, time / 2);
+    time -= std::min((int64_t) UCI::Options.moveOverhead.value, time / 2);
 
     // Figure out how we should spend this time
     if (parameters->movetime) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -70,9 +70,17 @@ namespace UCI {
             false
         };
 
+        UCIOption<UCI_SPIN> moveOverhead = {
+            "MoveOverhead",
+            100,
+            100,
+            10,
+            10000
+        };
+
         template <typename Func>
         void forEach(Func&& f) {
-            auto optionsTuple = std::make_tuple(&multiPV, &chess960);
+            auto optionsTuple = std::make_tuple(&multiPV, &moveOverhead, &chess960);
             for_each_in_tuple(optionsTuple, f);
         }
     };


### PR DESCRIPTION
Doesn't change anything, since the default value is identical to the previously used value, but here's a 5k game VSTC test just to be sure.

```
Elo   | -1.74 +- 6.78 (95%)
Conf  | 4.0+0.04s Threads=1 Hash=16MB
Games | N: 5000 W: 1230 L: 1255 D: 2515
Penta | [41, 600, 1240, 581, 38]
https://openbench.yoshie2000.de/test/733/
```

Bench: 4280561