### PR TITLE
More reduction for cut nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -630,7 +630,7 @@ movesLoop:
                 reducedDepth--;
 
             if (cutNode)
-                reducedDepth--;
+                reducedDepth -= 2;
 
             if (capture)
                 reducedDepth += moveHistory / lmrHistoryFactorCapture;


### PR DESCRIPTION
```
Elo   | 7.17 +- 5.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6346 W: 1561 L: 1430 D: 3355
Penta | [25, 715, 1573, 824, 36]
https://openbench.yoshie2000.de/test/739/
```

Bench: 4081006