### PR TITLE
Make bad capture SEE value depend on move history

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -600,9 +600,17 @@ int MoveGen::scoreGoodCaptures(int beginIndex, int endIndex) {
             continue;
         }
 
+        int score = *history->getCaptureHistory(board, move);
+        if ((move & 0x3000) == MOVE_ENPASSANT)
+            score += 0;
+        else if ((move & 0x3000) == MOVE_PROMOTION)
+            score += PIECE_VALUES[PROMOTION_PIECE[move >> 14]];
+        else
+            score += PIECE_VALUES[board->pieces[moveTarget(move)]] - PIECE_VALUES[board->pieces[moveOrigin(move)]];
+
         // Store bad captures in a separate list
         // In qsearch, the SEE check is done later
-        bool goodCapture = probCut ? SEE(board, move, probCutThreshold) : (onlyCaptures || SEE(board, move, -107));
+        bool goodCapture = probCut ? SEE(board, move, probCutThreshold) : (onlyCaptures || SEE(board, move, -score / 80));
         if (!goodCapture) {
             moveList[i] = moveList[endIndex - 1];
             moveList[endIndex - 1] = MOVE_NONE;
@@ -613,14 +621,7 @@ int MoveGen::scoreGoodCaptures(int beginIndex, int endIndex) {
             continue;
         }
 
-        int score;
-        if ((move & 0x3000) == MOVE_ENPASSANT)
-            score = 0;
-        else if ((move & 0x3000) == MOVE_PROMOTION)
-            score = PIECE_VALUES[PROMOTION_PIECE[move >> 14]];
-        else
-            score = PIECE_VALUES[board->pieces[moveTarget(move)]] - PIECE_VALUES[board->pieces[moveOrigin(move)]];
-        moveListScores[i] = score + *history->getCaptureHistory(board, move);
+        moveListScores[i] = score;
     }
     return endIndex;
 }


### PR DESCRIPTION
```
Elo   | 3.77 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15408 W: 3704 L: 3537 D: 8167
Penta | [77, 1789, 3837, 1892, 109]
https://openbench.yoshie2000.de/test/783/
```

Bench: 3932675