### PR TITLE
Don't search first pv move as non-pv node

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -693,7 +693,7 @@ movesLoop:
                 }
             }
         }
-        else {
+        else if (!pvNode || moveCount > 1) {
             value = -search<NON_PV_NODE>(board, stack + 1, thread, newDepth, -(alpha + 1), -alpha, !cutNode);
         }
 


### PR DESCRIPTION
```
Elo   | 16.31 +- 9.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2580 W: 654 L: 533 D: 1393
Penta | [11, 268, 621, 369, 21]
https://openbench.yoshie2000.de/test/791/
```

Bench: 3591042