### PR TITLE
Reduce following moves after alpha raise

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -679,7 +679,7 @@ movesLoop:
         if (doExtensions && extension == 0 && board->stack->checkers)
             extension = 1;
 
-        Eval value;
+        Eval value = 0;
         int newDepth = depth - 1 + extension;
 
         // Very basic LMR: Late moves are being searched with less depth
@@ -758,6 +758,9 @@ movesLoop:
                     thread->history.updateCaptureHistory(board, move, bonus, captureMoves, captureMoveCount);
                     break;
                 }
+
+                if (depth > 4 && depth < 10 && beta < EVAL_MATE_IN_MAX_PLY && value > -EVAL_MATE_IN_MAX_PLY)
+                    depth--;
             }
         }
 


### PR DESCRIPTION
```
Elo   | 2.21 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 43482 W: 10108 L: 9831 D: 23543
Penta | [198, 5127, 10847, 5338, 231]
https://openbench.yoshie2000.de/test/823/
```

Bench: 3587489