### PR TITLE
Increase pawn correction importance

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -20,7 +20,7 @@ void History::initHistory() {
 
 Eval History::correctStaticEval(Eval eval, Board* board) {
     Eval history = getCorrectionHistory(board);
-    Eval adjustedEval = eval + (history * std::abs(history)) / 16384;
+    Eval adjustedEval = eval + (history * std::abs(history)) / 12288;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_MATE_IN_MAX_PLY + 1, (int)EVAL_MATE_IN_MAX_PLY - 1);
     return adjustedEval;
 }


### PR DESCRIPTION
```
Elo   | 4.30 +- 3.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17768 W: 4168 L: 3948 D: 9652
Penta | [101, 2020, 4421, 2242, 100]
https://openbench.yoshie2000.de/test/831/
```

Bench: 3251520