### PR TITLE
Fix thread scaling issues

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -940,13 +940,13 @@ void Thread::tsearch() {
             }
         }
 
+        std::sort(result.rootMoves.begin(), result.rootMoves.end(), [](RootMove rm1, RootMove rm2) { return rm1.value > rm2.value; });
+
         if (mainThread) {
             // Send UCI info
             int64_t ms = getTime() - searchData.startTime;
             int64_t nodes = threadPool->nodesSearched();
             int64_t nps = ms == 0 ? 0 : nodes / ((double)ms / 1000);
-
-            std::sort(result.rootMoves.begin(), result.rootMoves.end(), [](RootMove rm1, RootMove rm2) { return rm1.value > rm2.value; });
 
             for (int rootMoveIdx = 0; rootMoveIdx < multiPvCount; rootMoveIdx++) {
                 RootMove rootMove = result.rootMoves[rootMoveIdx];


### PR DESCRIPTION
The SMP fix for CCC (d1f6fe1a87ae749314b7bb53c1227b6a25224009) introduced a scaling issue:
```
Elo   | 17.39 +- 30.96 (95%)
Conf  | 8.0+0.08s Threads=2 Hash=32MB
Games | N: 220 W: 55 L: 44 D: 121
Penta | [0, 24, 52, 33, 1]
https://openbench.yoshie2000.de/test/836/
```

This patch fixes these problems:
```
Elo   | 88.74 +- 15.17 (95%)
Conf  | 5.0+0.05s Threads=2 Hash=32MB
Games | N: 1000 W: 370 L: 120 D: 510
Penta | [3, 33, 198, 243, 23]
https://openbench.yoshie2000.de/test/838/
```

Bench: 3251520