### PR TITLE
Fix probcut in close-to-mated positions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -518,11 +518,11 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     }
 
     // ProbCut
-    probCutBeta = beta + probCutBetaOffset;
+    probCutBeta = std::min(beta + probCutBetaOffset, EVAL_MATE_IN_MAX_PLY - 1);
     if (!pvNode
         && !excluded
         && depth > probCutDepth
-        && std::abs(beta) < EVAL_MATE_IN_MAX_PLY
+        && std::abs(beta) < EVAL_MATE_IN_MAX_PLY - 1
         && !(ttDepth >= depth - 3 && ttValue != EVAL_NONE && ttValue < probCutBeta)) {
 
         assert(probCutBeta > beta);


### PR DESCRIPTION
```
Elo   | -0.34 +- 3.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.04 (-2.25, 2.89) [-2.25, 0.75]
Games | N: 23538 W: 5397 L: 5420 D: 12721
Penta | [101, 2506, 6574, 2491, 97]
https://openbench.yoshie2000.de/test/833/
```

Bench: 3251520