### PR TITLE
Minor memory initalization speedup

### DIFF
--- a/src/move.h
+++ b/src/move.h
@@ -181,7 +181,7 @@ class MoveGen {
     int returnedMoves;
     int killerCount;
 
-    Move badCaptureList[48]; // There can never be more than 32 pieces on the board => never more than 32 captures possible
+    Move badCaptureList[48];
     int badCaptureScores[48];
     int generatedBadCaptures; // Bad captures only count as "generated" when the corresponding stage sorts them
     int flaggedBadCaptures; // Before that, this counter will keep track of them
@@ -197,22 +197,16 @@ public:
 
     // Main search
     MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(false), killers{ searchStack->killers[0], searchStack->killers[1] }, moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), killerCount(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), flaggedBadCaptures(0), returnedBadCaptures(0), generationStage(GEN_STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0) {
-        std::fill(moveList, moveList + MAX_MOVES, MOVE_NONE);
-        std::fill(badCaptureList, badCaptureList + 32, MOVE_NONE);
         counterMove = searchStack->ply > 0 ? history->getCounterMove((searchStack - 1)->move) : MOVE_NONE;
     }
 
     // qSearch
     MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(onlyCaptures), killers{ MOVE_NONE, MOVE_NONE }, moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), killerCount(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), flaggedBadCaptures(0), returnedBadCaptures(0), generationStage(GEN_STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0) {
-        std::fill(moveList, moveList + MAX_MOVES, MOVE_NONE);
-        std::fill(badCaptureList, badCaptureList + 32, MOVE_NONE);
         counterMove = onlyCaptures || searchStack->ply == 0 ? MOVE_NONE : history->getCounterMove((searchStack - 1)->move);
     }
 
     // ProbCut
     MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int probCutThreshold, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(true), killers{ MOVE_NONE, MOVE_NONE }, moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), killerCount(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), flaggedBadCaptures(0), returnedBadCaptures(0), generationStage(GEN_STAGE_TTMOVE), depth(depth), probCut(true), probCutThreshold(probCutThreshold) {
-        std::fill(moveList, moveList + MAX_MOVES, MOVE_NONE);
-        std::fill(badCaptureList, badCaptureList + 32, MOVE_NONE);
         counterMove = MOVE_NONE;
     }
 


### PR DESCRIPTION
```
Elo   | 0.34 +- 5.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.25 (-2.25, 2.89) [-2.25, 0.75]
Games | N: 7256 W: 1714 L: 1707 D: 3835
Penta | [32, 798, 1965, 797, 36]
https://openbench.yoshie2000.de/test/840/
```

Bench: 3251520