### PR TITLE
More negative extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,8 +657,10 @@ movesLoop:
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
             else if (ttValue >= beta)
                 extension = -2;
-            // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low 2 different ways, so reduce
-            else if (cutNode && ttValue <= alpha)
+            // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low, so reduce
+            else if (cutNode)
+                extension = -2;
+            else if (ttValue <= alpha)
                 extension = -1;
         }
 


### PR DESCRIPTION
STC
```
Elo   | 0.66 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.37 (-2.25, 2.89) [0.00, 3.00]
Games | N: 59648 W: 13725 L: 13611 D: 32312
Penta | [327, 7039, 14979, 7151, 328]
https://openbench.yoshie2000.de/test/830/
```

LTC
```
Elo   | 1.54 +- 2.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.31 (-2.25, 2.89) [0.50, 3.50]
Games | N: 47692 W: 10583 L: 10372 D: 26737
Penta | [59, 5480, 12579, 5647, 81]
https://openbench.yoshie2000.de/test/841/
```

Bench: 3291214