### PR TITLE
Do IIR if ttDepth is far lower than current depth (credit to blackmarlin)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -463,7 +463,7 @@ Eval search(Board* board, SearchStack* stack, Thread* thread, int depth, Eval al
     }
 
     // IIR
-    if (ttMove == MOVE_NONE && depth >= iirMinDepth)
+    if ((ttMove == MOVE_NONE || ttDepth + 4 < depth) && depth >= iirMinDepth)
         depth--;
 
     // Improving


### PR DESCRIPTION
STC
```
Elo   | 6.21 +- 4.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11356 W: 2714 L: 2511 D: 6131
Penta | [45, 1273, 2864, 1426, 70]
https://openbench.yoshie2000.de/test/868/
```
Scaling test after tune
```
Elo   | 5.75 +- 6.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.30 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5080 W: 1171 L: 1087 D: 2822
Penta | [7, 536, 1369, 622, 6]
https://openbench.yoshie2000.de/test/870/
```

Bench: 2919244