### PR TITLE
Use lmrDepth for SEE pruning of quiet moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -620,7 +620,7 @@ movesLoop:
                 continue;
 
             // SEE Pruning
-            if (!pvNode && depth < seeDepth && !SEE(board, move, SEE_MARGIN[depth][!capture]))
+            if (!pvNode && depth < seeDepth && !SEE(board, move, SEE_MARGIN[!capture ? lmrDepth : depth][!capture]))
                 continue;
 
         }


### PR DESCRIPTION
```
Elo   | 4.26 +- 3.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17772 W: 4191 L: 3973 D: 9608
Penta | [82, 2026, 4462, 2224, 92]
https://openbench.yoshie2000.de/test/894/
```

Bench: 2816798