### PR TITLE
Reduce early lmr depth more if not improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -602,7 +602,7 @@ movesLoop:
             && hasNonPawns(board)
             ) {
 
-            int lmrDepth = std::max(0, depth - REDUCTIONS[!capture][depth][moveCount]);
+            int lmrDepth = std::max(0, depth - REDUCTIONS[!capture][depth][moveCount] - !improving);
 
             if (!pvNode && !skipQuiets && !board->stack->checkers) {
 


### PR DESCRIPTION
```
Elo   | 5.59 +- 4.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12930 W: 3066 L: 2858 D: 7006
Penta | [54, 1461, 3233, 1657, 60]
https://openbench.yoshie2000.de/test/903/
```

Bench: 2657029