### PR TITLE
Fix corrhist condition for fail lows

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -816,12 +816,13 @@ movesLoop:
     }
 
     // Insert into TT
+    bool alphaRaise = alpha != oldAlpha;
     int flags = bestValue >= beta ? TT_LOWERBOUND : alpha != oldAlpha ? TT_EXACTBOUND : TT_UPPERBOUND;
     if (!excluded)
         ttEntry->update(board->stack->hash, bestMove, depth, unadjustedEval, valueToTT(bestValue, stack->ply), ttPv, flags);
 
     // Adjust correction history
-    if (!board->stack->checkers && !isCapture(board, bestMove) && (bestValue < beta || bestValue > stack->staticEval)) {
+    if (!board->stack->checkers && !isCapture(board, bestMove) && (bestValue < beta || bestValue > stack->staticEval) && (alphaRaise || bestValue <= stack->staticEval)) {
         int bonus = std::clamp((int)(bestValue - stack->staticEval) * depth * correctionHistoryFactor / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
         thread->history.updateCorrectionHistory(board, bonus);
     }


### PR DESCRIPTION
```
Elo   | 5.83 +- 4.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12282 W: 2921 L: 2715 D: 6646
Penta | [52, 1381, 3091, 1543, 74]
https://openbench.yoshie2000.de/test/943/
```

Bench: 2453967