### PR TITLE
Fix tt in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -237,7 +237,6 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
     BoardStack boardStack;
     Move bestMove = MOVE_NONE;
     Eval bestValue, futilityValue, unadjustedEval;
-    Eval oldAlpha = alpha;
 
     // TT Lookup
     bool ttHit = false;
@@ -353,7 +352,7 @@ movesLoopQsearch:
     }
 
     // Insert into TT
-    int flags = bestValue >= beta ? TT_LOWERBOUND : alpha != oldAlpha ? TT_EXACTBOUND : TT_UPPERBOUND;
+    int flags = bestValue >= beta ? TT_LOWERBOUND : TT_UPPERBOUND;
     ttEntry->update(board->stack->hash, bestMove, 0, unadjustedEval, valueToTT(bestValue, stack->ply), ttPv, flags);
 
     return bestValue;

--- a/src/tt.h
+++ b/src/tt.h
@@ -55,7 +55,8 @@ struct TTEntry {
 
         if (_flags == TT_EXACTBOUND || (uint16_t)_hash != hash || _depth - TT_DEPTH_OFFSET + 2 * wasPv > depth - 4) {
             hash = (uint16_t)_hash;
-            bestMove = _bestMove;
+            if (_bestMove != MOVE_NONE)
+                bestMove = _bestMove;
             depth = _depth - TT_DEPTH_OFFSET;
             value = _value;
             eval = _eval;


### PR DESCRIPTION
```
Elo   | 4.71 +- 4.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10546 W: 2496 L: 2353 D: 5697
Penta | [38, 1149, 2770, 1264, 52]
https://openbench.yoshie2000.de/test/953/
```

Bench: 2268999