### PR TITLE
Use ttValue in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -267,6 +267,9 @@ Eval qsearch(Board* board, Thread* thread, SearchStack* stack, Eval alpha, Eval 
     else if (ttHit && ttEval != EVAL_NONE) {
         unadjustedEval = ttEval;
         stack->staticEval = bestValue = thread->history.correctStaticEval(unadjustedEval, board);
+    
+        if (ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue < bestValue) || (ttFlag == TT_LOWERBOUND && ttValue > bestValue) || (ttFlag == TT_EXACTBOUND)))
+            bestValue = ttValue;
     }
     else {
         unadjustedEval = evaluate(board, &thread->nnue);


### PR DESCRIPTION
```
Elo   | 4.29 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12242 W: 2862 L: 2711 D: 6669
Penta | [56, 1428, 3012, 1559, 66]
https://chess.aronpetkovski.com/test/98/
```

Bench: 2373779