### PR TITLE
Some minor optimizations

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -788,7 +788,6 @@ void updateSliderPins(Board* board, Color side) {
     Square king = lsb(board->byColor[side] & board->byPiece[PIECE_KING]);
 
     board->stack->blockers[side] = 0;
-    board->stack->pinners[1 - side] = 0;
 
     Bitboard possiblePinnersRook = getRookMoves(king, C64(0)) & (board->byPiece[PIECE_ROOK] | board->byPiece[PIECE_QUEEN]);
     Bitboard possiblePinnersBishop = getBishopMoves(king, C64(0)) & (board->byPiece[PIECE_BISHOP] | board->byPiece[PIECE_QUEEN]);
@@ -803,8 +802,6 @@ void updateSliderPins(Board* board, Color side) {
         if (__builtin_popcountll(blockerBB) == 1) {
             // We have exactly one blocker for this pinner
             board->stack->blockers[side] |= blockerBB;
-            if (blockerBB & board->byColor[side])
-                board->stack->pinners[1 - side] |= C64(1) << pinnerSquare;
         }
     }
 }

--- a/src/board.h
+++ b/src/board.h
@@ -47,7 +47,6 @@ struct BoardStack {
     uint64_t pawnHash;
 
     Bitboard blockers[2];
-    Bitboard pinners[2];
     Bitboard checkers;
     uint8_t checkerCount;
 

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -464,7 +464,7 @@ void generateMoves(Board* board, Move* moves, int* counter, bool onlyCaptures) {
 Move MoveGen::nextMove() {
     assert((board->byColor[board->stm] & board->byPiece[PIECE_KING]) > 0);
 
-    Move* moves = moveList + generatedMoves;
+    Move* moves;
     int beginIndex, endIndex;
 
     // Generate moves for the current stage
@@ -480,7 +480,7 @@ Move MoveGen::nextMove() {
 
     case GEN_STATE_GEN_CAPTURES:
         beginIndex = generatedMoves;
-
+        moves = moveList + generatedMoves;
         // If in double check, only generate king moves
         if (board->stack->checkerCount > 1) {
             generatePiece<PIECE_KING>(board, &moves, &generatedMoves, true, ~C64(0));
@@ -499,7 +499,6 @@ Move MoveGen::nextMove() {
         endIndex = generatedMoves;
 
         endIndex = scoreGoodCaptures(beginIndex, endIndex);
-        moves = moveList + generatedMoves;
         sortMoves(moveList, moveListScores, beginIndex, endIndex);
 
         generationStage++;
@@ -548,6 +547,7 @@ Move MoveGen::nextMove() {
 
     case GEN_STAGE_GEN_REMAINING:
         beginIndex = generatedMoves;
+        moves = moveList + generatedMoves;
         // If in double check, only generate king moves
         if (board->stack->checkerCount > 1) {
             generatePiece<PIECE_KING>(board, &moves, &generatedMoves, false, ~C64(0));
@@ -568,7 +568,6 @@ Move MoveGen::nextMove() {
         endIndex = generatedMoves;
 
         endIndex = scoreQuiets(beginIndex, endIndex);
-        moves = moveList + generatedMoves;
         sortMoves(moveList, moveListScores, beginIndex, endIndex);
 
         generationStage++;

--- a/src/move.h
+++ b/src/move.h
@@ -180,8 +180,8 @@ class MoveGen {
     int returnedMoves;
     int killerCount;
 
-    Move badCaptureList[48];
-    int badCaptureScores[48];
+    Move badCaptureList[MAX_CAPTURES];
+    int badCaptureScores[MAX_CAPTURES];
     int generatedBadCaptures; // Bad captures only count as "generated" when they are sorted out by SEE
     int returnedBadCaptures;
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -200,10 +200,10 @@ Eval NNUE::evaluate(Board* board) {
     int bucket = (pieceCount - 2) / divisor;
     assert(0 <= bucket && bucket < OUTPUT_BUCKETS);
 
-    Accumulator& accumulator = accumulatorStack[currentAccumulator];
+    Accumulator* accumulator = &accumulatorStack[currentAccumulator];
 
-    Vec* stmAcc = (Vec*)accumulator.colors[board->stm];
-    Vec* oppAcc = (Vec*)accumulator.colors[1 - board->stm];
+    Vec* stmAcc = (Vec*)accumulator->colors[board->stm];
+    Vec* oppAcc = (Vec*)accumulator->colors[1 - board->stm];
 
     Vec* stmWeights = (Vec*)&networkData.outputWeights[bucket][0];
     Vec* oppWeights = (Vec*)&networkData.outputWeights[bucket][HIDDEN_WIDTH];

--- a/src/types.h
+++ b/src/types.h
@@ -6,6 +6,7 @@
 
 #define MAX_PLY 246
 #define MAX_MOVES 218
+#define MAX_CAPTURES 74
 
 #define PIECE_TYPES 6
 


### PR DESCRIPTION
There is literally nothing that could regress, but anyway
```
Elo   | -0.20 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.20 (-2.25, 2.89) [-2.25, 0.75]
Games | N: 21080 W: 4838 L: 4850 D: 11392
Penta | [123, 2490, 5297, 2536, 94]
https://chess.aronpetkovski.com/test/120/
```

Bench: 2424208