### PR TITLE
More correction history weight

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -9,7 +9,7 @@
 
 TUNE_INT(contHistBonusFactor, 100, 50, 150);
 TUNE_INT(contHistMalusFactor, 100, 50, 150);
-TUNE_INT(correctionHistoryDivisor, 12061, 5000, 20000);
+TUNE_INT(correctionHistoryDivisor, 10000, 5000, 20000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));


### PR DESCRIPTION
```
Elo   | 2.78 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 30034 W: 6864 L: 6624 D: 16546
Penta | [94, 3468, 7692, 3630, 133]
https://chess.aronpetkovski.com/test/431/
```

Bench: 2414925