### PR TITLE
Threats in quiet move ordering

### DIFF
--- a/src/move.h
+++ b/src/move.h
@@ -211,7 +211,7 @@ public:
 
 private:
 
-    int scoreGoodCaptures(int beginIndex, int endIndex);
+    int scoreCaptures(int beginIndex, int endIndex);
     int scoreQuiets(int beginIndex, int endIndex);
 
     void sortMoves(Move* moves, int* scores, int beginIndex, int endIndex);


### PR DESCRIPTION
```
Elo   | 2.61 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33556 W: 7692 L: 7440 D: 18424
Penta | [136, 3893, 8485, 4111, 153]
https://chess.aronpetkovski.com/test/484/
```

Bench: 2637649