### PR TITLE
Threats in quiet move ordering (Fixed)

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -642,19 +642,19 @@ int MoveGen::scoreQuiets(int beginIndex, int endIndex) {
         Bitboard toBB = C64(1) << moveTarget(move);
         if (piece == PIECE_QUEEN) {
             if (fromBB & (pawnThreats | knightThreats | bishopThreats | rookThreats))
-                threatScore += 30000;
+                threatScore += 20000;
             if (toBB & (pawnThreats | knightThreats | bishopThreats | rookThreats))
-                threatScore -= 30000;
+                threatScore -= 20000;
         } else if (piece == PIECE_ROOK) {
             if (fromBB & (pawnThreats | knightThreats | bishopThreats))
-                threatScore += 15000;
+                threatScore += 12500;
             if (toBB & (pawnThreats | knightThreats | bishopThreats))
-                threatScore -= 15000;
+                threatScore -= 12500;
         } else if (piece == PIECE_KNIGHT || piece == PIECE_BISHOP) {
             if (fromBB & pawnThreats)
-                threatScore += 15000;
+                threatScore += 7500;
             if (toBB & pawnThreats)
-                threatScore -= 15000;
+                threatScore -= 7500;
         }
 
         moveListScores[i] = history->getHistory(board, searchStack, move, false) + threatScore;


### PR DESCRIPTION
```
Elo   | 2.61 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33556 W: 7692 L: 7440 D: 18424
Penta | [136, 3893, 8485, 4111, 153]
https://chess.aronpetkovski.com/test/484/
```

Bench: 2507778