### PR TITLE
King Buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Windows only flags
 ifeq ($(OS), Windows_NT)
-	CXXFLAGS := $(CXXFLAGS) -lstdc++ -static -Wl,--no-as-needed,--stack,16777216
+	CXXFLAGS := $(CXXFLAGS) -lstdc++ -static -Wl,--no-as-needed
 endif
 
 %.o:	%.cpp

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -32,10 +32,10 @@ namespace BB {
     }
 
     Bitboard knightAttacks(Bitboard knightBB) {
-        Bitboard l1 = (knightBB >> 1) & bitboard(0x7f7f7f7f7f7f7f7f);
-        Bitboard l2 = (knightBB >> 2) & bitboard(0x3f3f3f3f3f3f3f3f);
-        Bitboard r1 = (knightBB << 1) & bitboard(0xfefefefefefefefe);
-        Bitboard r2 = (knightBB << 2) & bitboard(0xfcfcfcfcfcfcfcfc);
+        Bitboard l1 = (knightBB >> 1) & Bitboard(0x7f7f7f7f7f7f7f7f);
+        Bitboard l2 = (knightBB >> 2) & Bitboard(0x3f3f3f3f3f3f3f3f);
+        Bitboard r1 = (knightBB << 1) & Bitboard(0xfefefefefefefefe);
+        Bitboard r2 = (knightBB << 2) & Bitboard(0xfcfcfcfcfcfcfcfc);
         Bitboard h1 = l1 | r1;
         Bitboard h2 = l2 | r2;
         return (h1 << 16) | (h1 >> 16) | (h2 << 8) | (h2 >> 8);

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1205,7 +1205,7 @@ int Board::validateBoard() {
     return -1;
 }
 
-void debugbitboard(Bitboard bb) {
+void debugBitboard(Bitboard bb) {
     for (int rank = 7; rank >= 0; rank--) {
 
         std::cout << "-";
@@ -1217,7 +1217,7 @@ void debugbitboard(Bitboard bb) {
         for (int file = 0; file <= 7; file++) {
 
             // Get piece at index
-            int idx = file + 8 * rank;
+            Square idx = file + 8 * rank;
             Bitboard mask = bitboard(idx);
             if ((bb & mask) == 0)
                 std::cout << "|   ";

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -553,6 +553,8 @@ void Board::doMove(BoardStack* newStack, Move move, uint64_t newHash, NNUE* nnue
     updateSliderPins(Color::WHITE);
     updateSliderPins(Color::BLACK);
 
+    nnue->finalizeMove(this);
+
     stm = flip(stm);
     newStack->move = move;
 }

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -230,6 +230,13 @@ struct Accumulator {
   Bitboard byPiece[2][Piece::TOTAL];
 };
 
+struct FinnyEntry {
+  alignas(ALIGNMENT) int16_t colors[2][HIDDEN_WIDTH];
+
+  Bitboard byColor[2][2];
+  Bitboard byPiece[2][Piece::TOTAL];
+};
+
 struct NetworkData {
   alignas(ALIGNMENT) int16_t featureWeights[KING_BUCKETS][INPUT_WIDTH * HIDDEN_WIDTH];
   alignas(ALIGNMENT) int16_t featureBiases[HIDDEN_WIDTH];
@@ -238,6 +245,7 @@ struct NetworkData {
 };
 
 extern NetworkData networkData;
+extern FinnyEntry finnyTable[2][KING_BUCKETS];
 
 void initNetworkData();
 
@@ -257,22 +265,25 @@ public:
   void incrementAccumulator();
   void decrementAccumulator();
   void finalizeMove(Board* board);
+
+  void reset(Board* board);
   template<Color side>
-  void refreshAccumulator(Board* board, Accumulator* acc);
+  void resetAccumulator(Board* board, Accumulator* acc);
 
   Eval evaluate(Board* board);
 
   template<Color side>
   void calculateAccumulators();
   template<Color side>
-  void addPieceToAccumulator(Accumulator* inputAcc, Accumulator* outputAcc, KingBucketInfo* kingBucket, Square square, Piece piece, Color pieceColor);
+  void refreshAccumulator(Accumulator* acc);
   template<Color side>
-  void removePieceFromAccumulator(Accumulator* inputAcc, Accumulator* outputAcc, KingBucketInfo* kingBucket, Square square, Piece piece, Color pieceColor);
+  void incrementallyUpdateAccumulator(Accumulator* inputAcc, Accumulator* outputAcc, KingBucketInfo* kingBucket);
+
   template<Color side>
-  void movePieceInAccumulator(Accumulator* inputAcc, Accumulator* outputAcc, KingBucketInfo* kingBucket, Square origin, Square target, Piece piece, Color pieceColor);
+  void addPieceToAccumulator(int16_t(* inputData)[HIDDEN_WIDTH], int16_t(* outputData)[HIDDEN_WIDTH], KingBucketInfo* kingBucket, Square square, Piece piece, Color pieceColor);
+  template<Color side>
+  void removePieceFromAccumulator(int16_t(* inputData)[HIDDEN_WIDTH], int16_t(* outputData)[HIDDEN_WIDTH], KingBucketInfo* kingBucket, Square square, Piece piece, Color pieceColor);
+  template<Color side>
+  void movePieceInAccumulator(int16_t(* inputData)[HIDDEN_WIDTH], int16_t(* outputData)[HIDDEN_WIDTH], KingBucketInfo* kingBucket, Square origin, Square target, Piece piece, Color pieceColor);
 
 };
-
-#include "board.h"
-
-void resetAccumulators(Board* board, NNUE* nnue);

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -171,15 +171,15 @@ inline int vecHaddEpi32(Vec vec) {
 #endif
 
 constexpr int INPUT_WIDTH = 768;
-constexpr int HIDDEN_WIDTH = 1536;
+constexpr int HIDDEN_WIDTH = 2048;
 
 constexpr uint8_t KING_BUCKET_LAYOUT[] = {
     0, 0, 1, 1, 1, 1, 0, 0,
-    2, 2, 3, 3, 3, 3, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,
+    3, 3, 3, 3, 3, 3, 3, 3,
     4, 4, 4, 4, 4, 4, 4, 4,
     5, 5, 5, 5, 5, 5, 5, 5,
-    6, 6, 6, 6, 6, 6, 6, 6,
-    6, 6, 6, 6, 6, 6, 6, 6,
+    5, 5, 5, 5, 5, 5, 5, 5,
     6, 6, 6, 6, 6, 6, 6, 6,
     6, 6, 6, 6, 6, 6, 6, 6
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,8 +160,7 @@ uint64_t perftInternal(Board* board, NNUE* nnue, int depth) {
 uint64_t perft(Board* board, int depth) {
     clock_t begin = clock();
     BoardStack stack;
-    NNUE nnue;
-    resetAccumulators(board, &nnue);
+    UCI::nnue.reset(board);
 
     Move moves[MAX_MOVES] = { MOVE_NONE };
     int moveCount = 0;
@@ -174,9 +173,9 @@ uint64_t perft(Board* board, int depth) {
         if (!board->isLegal(move))
             continue;
 
-        board->doMove(&stack, move, board->hashAfter(move), &nnue);
-        uint64_t subNodes = perftInternal(board, &nnue, depth - 1);
-        board->undoMove(move, &nnue);
+        board->doMove(&stack, move, board->hashAfter(move), &UCI::nnue);
+        uint64_t subNodes = perftInternal(board, &UCI::nnue, depth - 1);
+        board->undoMove(move, &UCI::nnue);
 
         std::cout << moveToString(move, UCI::Options.chess960.value) << ": " << subNodes << std::endl;
 
@@ -850,7 +849,7 @@ void Thread::tsearch() {
     if (TUNE_ENABLED)
         initReductions();
 
-    resetAccumulators(&rootBoard, &nnue);
+    nnue.reset(&rootBoard);
 
     searchData.nodesSearched = 0;
     if (mainThread)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -331,7 +331,7 @@ void position(std::string line, Board* board, std::deque<BoardStack>* stackQueue
     }
 
     // Make further moves
-    resetAccumulators(board, &UCI::nnue);
+    UCI::nnue.reset(board);
     if (matchesToken(line, "moves")) {
         line = line.substr(6);
 
@@ -353,7 +353,7 @@ void position(std::string line, Board* board, std::deque<BoardStack>* stackQueue
             board->doMove(&stackQueue->back(), m, board->hashAfter(m), &UCI::nnue);
 
             if (moveCount++ > 200) {
-                resetAccumulators(board, &UCI::nnue);
+                UCI::nnue.reset(board);
             }
 
             if (line.length() > i)
@@ -535,7 +535,7 @@ void uciLoop(int argc, char* argv[]) {
         else if (matchesToken(line, "perfttest")) perfttest(&stackQueue, &board);
         else if (matchesToken(line, "debug")) board.debugBoard();
         else if (matchesToken(line, "eval")) {
-            resetAccumulators(&board, &UCI::nnue);
+            UCI::nnue.reset(&board);
             std::cout << formatEval(evaluate(&board, &UCI::nnue)) << std::endl;
         }
         else if (matchesToken(line, "seetest")) seetest(&board);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -21,6 +21,7 @@
 
 namespace UCI {
     UCIOptions Options;
+    NNUE nnue;
 }
 
 ThreadPool threads;
@@ -330,8 +331,7 @@ void position(std::string line, Board* board, std::deque<BoardStack>* stackQueue
     }
 
     // Make further moves
-    NNUE nnue;
-    resetAccumulators(board, &nnue);
+    resetAccumulators(board, &UCI::nnue);
     if (matchesToken(line, "moves")) {
         line = line.substr(6);
 
@@ -350,10 +350,10 @@ void position(std::string line, Board* board, std::deque<BoardStack>* stackQueue
             Move m = stringToMove(move, board);
 
             stackQueue->emplace_back();
-            board->doMove(&stackQueue->back(), m, board->hashAfter(m), &nnue);
+            board->doMove(&stackQueue->back(), m, board->hashAfter(m), &UCI::nnue);
 
             if (moveCount++ > 200) {
-                resetAccumulators(board, &nnue);
+                resetAccumulators(board, &UCI::nnue);
             }
 
             if (line.length() > i)
@@ -535,9 +535,8 @@ void uciLoop(int argc, char* argv[]) {
         else if (matchesToken(line, "perfttest")) perfttest(&stackQueue, &board);
         else if (matchesToken(line, "debug")) board.debugBoard();
         else if (matchesToken(line, "eval")) {
-            NNUE nnue;
-            resetAccumulators(&board, &nnue);
-            std::cout << formatEval(evaluate(&board, &nnue)) << std::endl;
+            resetAccumulators(&board, &UCI::nnue);
+            std::cout << formatEval(evaluate(&board, &UCI::nnue)) << std::endl;
         }
         else if (matchesToken(line, "seetest")) seetest(&board);
         else std::cout << "Unknown command" << std::endl;

--- a/src/uci.h
+++ b/src/uci.h
@@ -2,6 +2,8 @@
 
 #include <tuple>
 
+#include "nnue.h"
+
 constexpr auto VERSION = "2.0.0-dev";
 
 template<int... Is>
@@ -24,6 +26,8 @@ void for_each_in_tuple(std::tuple<Ts...> const& t, Func f) {
 }
 
 namespace UCI {
+
+    extern NNUE nnue;
 
     enum UCIOptionType {
         UCI_SPIN,


### PR DESCRIPTION
```
Elo   | 17.07 +- 7.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3932 W: 1069 L: 876 D: 1987
Penta | [21, 387, 983, 528, 47]
https://chess.aronpetkovski.com/test/566/
```

Also includes functional finny tables for faster accumulator refreshing:
```
Elo   | 10.04 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6300 W: 1462 L: 1280 D: 3558
Penta | [13, 622, 1708, 784, 23]
https://chess.aronpetkovski.com/test/559/
```

Bench: 2525547