### PR TITLE
Better thread voting

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -431,7 +431,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     if (!excluded) {
         ttEntry = TT.probe(board->stack->hash, &ttHit);
         if (ttHit) {
-            ttMove = ttEntry->getMove();
+            ttMove = rootNode && rootMoves[0].value > -EVAL_INFINITE ? rootMoves[0].move : ttEntry->getMove();
             ttValue = valueFromTt(ttEntry->getValue(), stack->ply);
             ttEval = ttEntry->getEval();
             ttDepth = ttEntry->getDepth();
@@ -959,6 +959,8 @@ void Thread::iterativeDeepening() {
             while (true) {
                 int searchDepth = std::max(1, depth - failHighs);
                 value = search<ROOT_NODE>(&rootBoard, stack, searchDepth, alpha, beta, false);
+
+                std::sort(rootMoves.begin(), rootMoves.end(), [](RootMove rm1, RootMove rm2) { return rm1.value > rm2.value; });
 
                 // Stop if we need to
                 if (stopped || exiting)


### PR DESCRIPTION
Keep partial results:
```
Elo   | 0.10 +- 1.94 (95%)
SPRT  | 4.0+0.04s Threads=4 Hash=64MB
LLR   | -1.79 (-2.25, 2.89) [0.00, 3.00]
Games | N: 55404 W: 12462 L: 12446 D: 30496
Penta | [154, 6432, 14516, 6444, 156]
https://chess.aronpetkovski.com/test/742/
```

Better thread voting:
```
Elo   | 5.51 +- 4.02 (95%)
SPRT  | 4.0+0.04s Threads=4 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12674 W: 2901 L: 2700 D: 7073
Penta | [33, 1415, 3251, 1594, 44]
https://chess.aronpetkovski.com/test/748/
```

Bench: 2693967