### PR TITLE
Introduce the second move's color in conthist

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -41,7 +41,7 @@ int History::getHistory(Board* board, BoardStack* boardStack, SearchStack* searc
         return *getCaptureHistory(board, move);
     }
     else {
-        return getQuietHistory(move, board->stm, board, boardStack) + 2 * getContinuationHistory(searchStack, board->pieces[moveOrigin(move)], move) + getPawnHistory(board, move);
+        return getQuietHistory(move, board->stm, board, boardStack) + 2 * getContinuationHistory(searchStack, board->stm, board->pieces[moveOrigin(move)], move) + getPawnHistory(board, move);
     }
 }
 
@@ -65,12 +65,12 @@ void History::updatePawnHistory(Board* board, Move move, int16_t bonus) {
     pawnHistory[board->stack->pawnHash & (PAWN_HISTORY_SIZE - 1)][board->stm][board->pieces[moveOrigin(move)]][moveTarget(move)] += scaledBonus;
 }
 
-int History::getContinuationHistory(SearchStack* stack, Piece piece, Move move) {
+int History::getContinuationHistory(SearchStack* stack, Color side, Piece piece, Move move) {
     assert(piece != Piece::NONE);
     Square target = moveTarget(move);
 
     int score = 0;
-    int pieceTo = 64 * piece + target;
+    int pieceTo = 2 * 64 * piece + 2 * target + side;
 
     if ((stack - 1)->movedPiece != Piece::NONE)
         score += (stack - 1)->contHist[pieceTo];
@@ -84,12 +84,12 @@ int History::getContinuationHistory(SearchStack* stack, Piece piece, Move move) 
     return score;
 }
 
-void History::updateContinuationHistory(SearchStack* stack, Piece piece, Move move, int16_t bonus) {
+void History::updateContinuationHistory(SearchStack* stack, Color side, Piece piece, Move move, int16_t bonus) {
     assert(piece != Piece::NONE);
     Square target = moveTarget(move);
 
-    int16_t scaledBonus = bonus - getContinuationHistory(stack, piece, move) * std::abs(bonus) / 32000;
-    int pieceTo = 64 * piece + target;
+    int16_t scaledBonus = bonus - getContinuationHistory(stack, side, piece, move) * std::abs(bonus) / 32000;
+    int pieceTo = 2 * 64 * piece + 2 * target + side;
 
     if ((stack - 1)->movedPiece != Piece::NONE)
         (stack - 1)->contHist[pieceTo] += scaledBonus;
@@ -139,7 +139,7 @@ void History::updateCaptureHistory(Board* board, Move move, int16_t bonus, Move*
 void History::updateQuietHistories(Board* board, BoardStack* boardStack, SearchStack* stack, Move move, int16_t bonus, Move* quietMoves, int quietMoveCount) {
     // Increase stats for this move
     updateQuietHistory(move, board->stm, board, boardStack, bonus);
-    updateContinuationHistory(stack, board->pieces[moveOrigin(move)], move, bonus * 100 / contHistBonusFactor);
+    updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(move)], move, bonus * 100 / contHistBonusFactor);
     updatePawnHistory(board, move, bonus);
 
     // Decrease stats for all other quiets
@@ -147,7 +147,7 @@ void History::updateQuietHistories(Board* board, BoardStack* boardStack, SearchS
         Move qMove = quietMoves[i];
         if (move == qMove) continue;
         updateQuietHistory(qMove, board->stm, board, boardStack, -bonus);
-        updateContinuationHistory(stack, board->pieces[moveOrigin(qMove)], qMove, -bonus * 100 / contHistMalusFactor);
+        updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(qMove)], qMove, -bonus * 100 / contHistMalusFactor);
         updatePawnHistory(board, qMove, -bonus);
     }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -17,7 +17,7 @@ class History {
 
 public:
 
-    int16_t continuationHistory[2][Piece::TOTAL][64][Piece::TOTAL * 64];
+    int16_t continuationHistory[2][Piece::TOTAL][64][Piece::TOTAL * 64 * 2];
 
     void initHistory();
 
@@ -32,8 +32,8 @@ public:
     int16_t getQuietHistory(Move move, Color stm, Board* board, BoardStack* stack);
     void updateQuietHistory(Move move, Color stm, Board* board, BoardStack* stack, int16_t bonus);
 
-    int getContinuationHistory(SearchStack* stack, Piece piece, Move move);
-    void updateContinuationHistory(SearchStack* stack, Piece piece, Move move, int16_t bonus);
+    int getContinuationHistory(SearchStack* stack, Color side, Piece piece, Move move);
+    void updateContinuationHistory(SearchStack* stack, Color side, Piece piece, Move move, int16_t bonus);
 
     int16_t* getCaptureHistory(Board* board, Move move);
     void updateSingleCaptureHistory(Board* board, Move move, int16_t bonus);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -750,7 +750,7 @@ movesLoop:
 
                 if (!capture) {
                     int bonus = std::min(lmrPassBonusBase + lmrPassBonusFactor * depth, lmrPassBonusMax);
-                    history.updateContinuationHistory(stack, stack->movedPiece, move, bonus);
+                    history.updateContinuationHistory(stack, flip(board->stm), stack->movedPiece, move, bonus);
                 }
             }
         }


### PR DESCRIPTION
```
Elo   | 1.95 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49916 W: 11216 L: 10936 D: 27764
Penta | [138, 5752, 12900, 6028, 140]
https://chess.aronpetkovski.com/test/897/
```

Bench: 2449449