### PR TITLE
No FP for promotions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -630,9 +630,11 @@ movesLoop:
 
                 // Futility pruning
                 if (capture) {
-                    Piece capturedPiece = moveType(move) == MOVE_ENPASSANT ? Piece::PAWN : board->pieces[moveTarget(move)];
-                    if (lmrDepth < 9 && eval + 450 + PIECE_VALUES[capturedPiece] + 325 * lmrDepth <= alpha)
-                        continue;
+                    if (moveType(move) != MOVE_PROMOTION) {
+                        Piece capturedPiece = moveType(move) == MOVE_ENPASSANT ? Piece::PAWN : board->pieces[moveTarget(move)];
+                        if (lmrDepth < 9 && eval + 450 + PIECE_VALUES[capturedPiece] + 325 * lmrDepth <= alpha)
+                            continue;
+                    }
                 }
                 else {
                     if (lmrDepth < fpDepth && eval + fpBase + fpFactor * lmrDepth <= alpha)


### PR DESCRIPTION
Eh this is good enough, pruning promos can't be bad
```
Elo   | -0.33 +- 1.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.17 (-2.25, 2.89) [-2.25, 0.75]
Games | N: 81216 W: 17911 L: 17987 D: 45318
Penta | [211, 8902, 22474, 8794, 227]
https://chess.aronpetkovski.com/test/966/
```

Bench: 2450175