### PR TITLE
Second IIR right before moves loop

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -596,6 +596,10 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
     assert(board->stack);
 
+    // IIR 2: Electric boolagoo
+    if (!ttHit && depth >= iirMinDepth && pvNode)
+        depth--;
+
 movesLoop:
 
     Move quietMoves[32];


### PR DESCRIPTION
```
Elo   | 1.68 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64688 W: 14528 L: 14215 D: 35945
Penta | [184, 7422, 16833, 7707, 198]
https://chess.aronpetkovski.com/test/1188/
```

Bench: 2498319