### PR TITLE
Remove depth cap in SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -668,7 +668,7 @@ movesLoop:
                 continue;
 
             // SEE Pruning
-            if (depth < seeDepth && !SEE(board, move, SEE_MARGIN[!capture ? lmrDepth : depth][!capture]))
+            if (!SEE(board, move, SEE_MARGIN[!capture ? lmrDepth : depth][!capture]))
                 continue;
 
         }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -547,7 +547,7 @@ void uciLoop(int argc, char* argv[]) {
         else if (matchesToken(line, "debug")) board.debugBoard();
         else if (matchesToken(line, "eval")) {
             UCI::nnue.reset(&board);
-            std::cout << formatEval(evaluate(&board, &UCI::nnue)) << std::endl;
+            std::cout << UCI::nnue.evaluate(&board) << std::endl;
         }
         else if (matchesToken(line, "seetest")) seetest(&board);
         else std::cout << "Unknown command" << std::endl;


### PR DESCRIPTION
```
Elo   | 4.71 +- 2.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15110 W: 3512 L: 3307 D: 8291
Penta | [40, 1697, 3896, 1862, 60]
https://chess.aronpetkovski.com/test/1690/
```

Bench: 2268122