### PR TITLE
Put more weight on the first conthist entry

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -71,7 +71,7 @@ int History::getContinuationHistory(SearchStack* stack, Color side, Piece piece,
     int pieceTo = 2 * 64 * piece + 2 * target + side;
 
     if ((stack - 1)->movedPiece != Piece::NONE)
-        score += (stack - 1)->contHist[pieceTo];
+        score += 2 * (stack - 1)->contHist[pieceTo];
 
     if ((stack - 2)->movedPiece != Piece::NONE)
         score += (stack - 2)->contHist[pieceTo];


### PR DESCRIPTION
```
Elo   | 3.36 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22738 W: 5204 L: 4984 D: 12550
Penta | [58, 2575, 5895, 2771, 70]
https://chess.aronpetkovski.com/test/2024/
```

Bench: 2307918