### PR TITLE
Use history in early pruning lmr depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -640,7 +640,7 @@ movesLoop:
             && board->hasNonPawns()
             ) {
 
-            int lmrDepth = std::max(0, depth - REDUCTIONS[!capture][depth][moveCount] - !improving);
+            int lmrDepth = std::max(0, depth - REDUCTIONS[!capture][depth][moveCount] - !improving + moveHistory / (capture ? lmrHistoryFactorCapture : lmrHistoryFactorQuiet));
 
             if (!skipQuiets && !board->stack->checkers) {
 


### PR DESCRIPTION
```
Elo   | 2.45 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34734 W: 7931 L: 7686 D: 19117
Penta | [88, 3924, 9105, 4155, 95]
https://chess.aronpetkovski.com/test/2091/
```

Bench: 2229675