### PR TITLE
Different quantisation

### DIFF
--- a/src/nnue.h
+++ b/src/nnue.h
@@ -183,7 +183,7 @@ constexpr int KING_BUCKETS = 7;
 constexpr int OUTPUT_BUCKETS = 8;
 
 constexpr int NETWORK_SCALE = 400;
-constexpr int NETWORK_QA = 255;
+constexpr int NETWORK_QA = 510;
 constexpr int NETWORK_QB = 64;
 constexpr int NETWORK_QAB = NETWORK_QA * NETWORK_QB;
 

--- a/tools/process_net.cpp
+++ b/tools/process_net.cpp
@@ -11,7 +11,7 @@ constexpr int KING_BUCKETS = 7;
 constexpr int OUTPUT_BUCKETS = 8;
 
 constexpr int NETWORK_SCALE = 400;
-constexpr int NETWORK_QA = 255;
+constexpr int NETWORK_QA = 512;
 constexpr int NETWORK_QB = 64;
 constexpr int NETWORK_QAB = NETWORK_QA * NETWORK_QB;
 


### PR DESCRIPTION
STC
```
Elo   | 5.03 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14036 W: 3290 L: 3087 D: 7659
Penta | [34, 1583, 3594, 1760, 47]
https://chess.aronpetkovski.com/test/2164/
```

Verification of the last 2 patches at LTC
```
Elo   | 3.85 +- 2.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18416 W: 4171 L: 3967 D: 10278
Penta | [13, 2066, 4847, 2268, 14]
https://chess.aronpetkovski.com/test/2166/
```

Bench: 2275548