### PR TITLE
14k LTC tune iterations

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,7 +7,7 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(correctionHistoryDivisor, 8462, 5000, 20000);
+TUNE_INT(correctionHistoryDivisor, 8413, 5000, 20000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -13,8 +13,8 @@
 #include "spsa.h"
 #include "history.h"
 
-TUNE_INT(mpPromotionScoreFactor, 141, 10, 10000);
-TUNE_INT(mpMvvLvaScoreFactor, 99, 10, 10000);
+TUNE_INT(mpPromotionScoreFactor, 99, 10, 10000);
+TUNE_INT(mpMvvLvaScoreFactor, 42, 10, 10000);
 TUNE_INT(mpSeeDivisor, 78, 10, 150);
 
 void generatePawn_quiet(Board* board, Move** moves, int* counter, Bitboard targetMask) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -22,40 +22,40 @@
 #include "uci.h"
 
 // Time management
-TUNE_FLOAT(tmInitialAdjustment, 1.074024309738491f, 0.5f, 1.5f);
+TUNE_FLOAT(tmInitialAdjustment, 1.0689767909418302f, 0.5f, 1.5f);
 TUNE_INT(tmBestMoveStabilityMax, 18, 10, 30);
-TUNE_FLOAT(tmBestMoveStabilityBase, 1.4620386652230069f, 0.75f, 2.5f);
-TUNE_FLOAT(tmBestMoveStabilityFactor, 0.048408976079429296f, 0.001f, 0.1f);
-TUNE_FLOAT(tmEvalDiffBase, 0.9648812218687435f, 0.5f, 1.5f);
-TUNE_FLOAT(tmEvalDiffFactor, 0.008792862698182788f, 0.001f, 0.1f);
-TUNE_INT(tmEvalDiffMin, -13, -250, 50);
-TUNE_INT(tmEvalDiffMax, 49, -50, 250);
-TUNE_FLOAT(tmNodesBase, 1.7783857265644578f, 0.5f, 5.0f);
-TUNE_FLOAT(tmNodesFactor, 0.8206315561804288f, 0.1f, 2.5f);
+TUNE_FLOAT(tmBestMoveStabilityBase, 1.4549948294458988f, 0.75f, 2.5f);
+TUNE_FLOAT(tmBestMoveStabilityFactor, 0.04793584499537653f, 0.001f, 0.1f);
+TUNE_FLOAT(tmEvalDiffBase, 0.9642911910576641f, 0.5f, 1.5f);
+TUNE_FLOAT(tmEvalDiffFactor, 0.00880073925849653f, 0.001f, 0.1f);
+TUNE_INT(tmEvalDiffMin, -15, -250, 50);
+TUNE_INT(tmEvalDiffMax, 52, -50, 250);
+TUNE_FLOAT(tmNodesBase, 1.7531235374124878f, 0.5f, 5.0f);
+TUNE_FLOAT(tmNodesFactor, 0.8334811378263333f, 0.1f, 2.5f);
 
 // Aspiration windows
 TUNE_INT(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT(aspirationWindowDelta, 15, 1, 30);
 TUNE_INT(aspirationWindowMaxFailHighs, 3, 1, 10);
-TUNE_FLOAT(aspirationWindowDeltaFactor, 1.6856094298665951f, 1.0f, 3.0f);
+TUNE_FLOAT(aspirationWindowDeltaFactor, 1.6898767279036404f, 1.0f, 3.0f);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.3921264879785859f, -2.0f, -0.1f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.157935164726898f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 0.8676168574488727f, 0.50f, 1.5f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.9400285113909232f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.4054958739683855f, -2.0f, -0.1f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 3.1337995071472053f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 0.8621398876747035f, 0.50f, 1.5f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.956049816742279f, 2.0f, 4.0f);
 
-TUNE_FLOAT(seeMarginNoisy, -22.383241222433632f, -50.0f, -10.0f);
-TUNE_FLOAT(seeMarginQuiet, -72.35512911050579f, -100.0f, -50.0f);
-TUNE_FLOAT(lmpMarginWorseningBase, 1.6838051754701528f, -1.0f, 2.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.3555618040676293f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.6975109221822988f, 1.0f, 3.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 3.054205956667065f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 1.0139193307608014f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 1.9142148491862292f, 1.0f, 3.0f);
+TUNE_FLOAT(seeMarginNoisy, -22.19272473360288f, -50.0f, -10.0f);
+TUNE_FLOAT(seeMarginQuiet, -72.01351432924626f, -100.0f, -50.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.6693555831128442f, -1.0f, 2.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.34260445262258654f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.6897807253089807f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 3.04534437912565f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 1.0274633935794744f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 1.8893886378038327f, 1.0f, 3.0f);
 
 // Search values
-TUNE_INT(qsFutilityOffset, 59, 1, 125);
+TUNE_INT(qsFutilityOffset, 57, 1, 125);
 TUNE_INT(qsSeeMargin, -103, -200, 50);
 
 // Pre-search pruning
@@ -63,37 +63,37 @@ TUNE_INT_DISABLED(iirMinDepth, 4, 1, 10);
 
 TUNE_INT(worseningOffset, 15, 1, 50);
 
-TUNE_INT(staticHistoryFactor, -51, -500, -1);
-TUNE_INT(staticHistoryMin, -79, -1000, -1);
-TUNE_INT(staticHistoryMax, 78, 1, 1000);
+TUNE_INT(staticHistoryFactor, -48, -500, -1);
+TUNE_INT(staticHistoryMin, -84, -1000, -1);
+TUNE_INT(staticHistoryMax, 71, 1, 1000);
 
 TUNE_INT_DISABLED(rfpDepth, 8, 2, 20);
-TUNE_INT(rfpFactor, 86, 1, 250);
+TUNE_INT(rfpFactor, 81, 1, 250);
 
 TUNE_INT_DISABLED(razoringDepth, 5, 2, 20);
-TUNE_INT(razoringFactor, 252, 1, 1000);
+TUNE_INT(razoringFactor, 247, 1, 1000);
 
 TUNE_INT_DISABLED(nmpRedBase, 3, 1, 5);
 TUNE_INT_DISABLED(nmpDepthDiv, 3, 1, 6);
 TUNE_INT_DISABLED(nmpMin, 3, 1, 10);
 TUNE_INT(nmpDivisor, 95, 10, 1000);
 
-TUNE_INT(probCutBetaOffset, 209, 1, 500);
+TUNE_INT(probCutBetaOffset, 198, 1, 500);
 TUNE_INT_DISABLED(probCutDepth, 5, 1, 15);
 
 // In-search pruning
 TUNE_INT_DISABLED(fpDepth, 11, 1, 20);
-TUNE_INT(fpBase, 252, 1, 1000);
-TUNE_INT(fpFactor, 118, 1, 500);
+TUNE_INT(fpBase, 253, 1, 1000);
+TUNE_INT(fpFactor, 116, 1, 500);
 
 TUNE_INT_DISABLED(fpCaptDepth, 9, 1, 20);
-TUNE_INT(fpCaptBase, 453, 150, 750);
-TUNE_INT(fpCaptFactor, 332, 100, 600);
+TUNE_INT(fpCaptBase, 448, 150, 750);
+TUNE_INT(fpCaptFactor, 330, 100, 600);
 
 TUNE_INT_DISABLED(historyPruningDepth, 4, 1, 15);
-TUNE_INT(historyPruningFactor, -2493, -8192, -128);
+TUNE_INT(historyPruningFactor, -2460, -8192, -128);
 
-TUNE_INT(doubleExtensionMargin, 16, 1, 30);
+TUNE_INT(doubleExtensionMargin, 15, 1, 30);
 TUNE_INT(doubleExtensionDepthIncrease, 11, 2, 20);
 
 TUNE_INT_DISABLED(seeDepth, 9, 2, 15);
@@ -102,21 +102,21 @@ TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMinDepth, 3, 1, 10);
 
-TUNE_INT(lmrHistoryFactorQuiet, 16252, 128, 32768);
-TUNE_INT(lmrHistoryFactorCapture, 12205, 128, 32768);
+TUNE_INT(lmrHistoryFactorQuiet, 16184, 128, 32768);
+TUNE_INT(lmrHistoryFactorCapture, 12370, 128, 32768);
 TUNE_INT(lmrDeeperBase, 39, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
 
-TUNE_INT(lmrPassBonusBase, -130, -500, 500);
-TUNE_INT(lmrPassBonusFactor, 160, 1, 500);
-TUNE_INT(lmrPassBonusMax, 1090, 32, 4096);
+TUNE_INT(lmrPassBonusBase, -132, -500, 500);
+TUNE_INT(lmrPassBonusFactor, 164, 1, 500);
+TUNE_INT(lmrPassBonusMax, 1115, 32, 4096);
 
-TUNE_INT(historyBonusBase, 21, -500, 500);
-TUNE_INT(historyBonusFactor, 191, 1, 500);
-TUNE_INT(historyBonusMax, 1678, 32, 4096);
-TUNE_INT(historyBonusBetaOffset, 277, 1, 500);
+TUNE_INT(historyBonusBase, 32, -500, 500);
+TUNE_INT(historyBonusFactor, 193, 1, 500);
+TUNE_INT(historyBonusMax, 1748, 32, 4096);
+TUNE_INT(historyBonusBetaOffset, 266, 1, 500);
 
-TUNE_INT(correctionHistoryFactor, 158, 32, 512);
+TUNE_INT(correctionHistoryFactor, 168, 32, 512);
 
 int REDUCTIONS[2][MAX_PLY][MAX_MOVES];
 int SEE_MARGIN[MAX_PLY][2];

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -4,11 +4,11 @@
 #include "uci.h"
 #include "spsa.h"
 
-TUNE_INT(maxTimeFactor, 753, 500, 1000);
-TUNE_INT(totalTimeDivisor, 169, 50, 500);
+TUNE_INT(maxTimeFactor, 757, 500, 1000);
+TUNE_INT(totalTimeDivisor, 167, 50, 500);
 TUNE_INT(totalTimeIncrementDivisor, 14, 5, 50);
-TUNE_FLOAT(optTimeFactor, 0.8226339350476581f, 0.5f, 1.5f);
-TUNE_FLOAT(maxTimeFactor2, 2.622627148146087f, 1.5f, 3.5f);
+TUNE_FLOAT(optTimeFactor, 0.8183818631572635f, 0.5f, 1.5f);
+TUNE_FLOAT(maxTimeFactor2, 2.6604544142070137f, 1.5f, 3.5f);
 
 int64_t getTime() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();


### PR DESCRIPTION
STC
```
Elo   | 1.28 +- 2.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.66 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29906 W: 6857 L: 6747 D: 16302
Penta | [158, 3563, 7439, 3597, 196]
https://chess.aronpetkovski.com/test/2712/
```

LTC
```
Elo   | 3.31 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.82 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21734 W: 4788 L: 4581 D: 12365
Penta | [33, 2403, 5781, 2624, 26]
https://chess.aronpetkovski.com/test/2714/
```

Bench: 2578811