### PR TITLE
Introduce material scale in the evaluation

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -28,10 +28,25 @@ constexpr Eval SEE_VALUES[Piece::TOTAL + 1] = {
 };
 
 
+int getMaterialScale(Board* board) {
+    int knightCount = board->stack->pieceCount[Color::WHITE][Piece::KNIGHT] + board->stack->pieceCount[Color::BLACK][Piece::KNIGHT];
+    int bishopCount = board->stack->pieceCount[Color::WHITE][Piece::BISHOP] + board->stack->pieceCount[Color::BLACK][Piece::BISHOP];
+    int rookCount = board->stack->pieceCount[Color::WHITE][Piece::ROOK] + board->stack->pieceCount[Color::BLACK][Piece::ROOK];
+    int queenCount = board->stack->pieceCount[Color::WHITE][Piece::QUEEN] + board->stack->pieceCount[Color::BLACK][Piece::QUEEN];
+
+    int materialValue = PIECE_VALUES[Piece::KNIGHT] * knightCount + PIECE_VALUES[Piece::BISHOP] * bishopCount + PIECE_VALUES[Piece::ROOK] * rookCount + PIECE_VALUES[Piece::QUEEN] * queenCount;
+    return materialScaleBase + materialValue / materialScaleDivisor;
+}
+
 Eval evaluate(Board* board, NNUE* nnue) {
     assert(!board->stack->checkers);
 
-    return nnue->evaluate(board);
+    Eval eval = nnue->evaluate(board);
+    eval = (eval * getMaterialScale(board)) / 1024;
+    // eval = eval * (220 - board->stack->rule50_ply) / 220;
+
+    eval = std::clamp((int) eval, (int) -EVAL_MATE_IN_MAX_PLY + 1, (int) EVAL_MATE_IN_MAX_PLY - 1);
+    return eval;
 }
 
 std::string formatEval(Eval value) {


### PR DESCRIPTION
```
Elo   | 6.08 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11538 W: 2664 L: 2462 D: 6412
Penta | [55, 1263, 2937, 1453, 61]
https://chess.aronpetkovski.com/test/2793/
```

Bench: 2261984