### PR TITLE
Piece probability distribution for datagen positions

### DIFF
--- a/src/datagen.cpp
+++ b/src/datagen.cpp
@@ -39,7 +39,19 @@ bool playRandomMoves(Board* board, Thread* thread, int remainingMoves) {
     }
 
     BoardStack boardStack;
-    Move move = legalMoves[std::rand() % legalMoves.size()];
+    Move move = MOVE_NONE;
+    while (move == MOVE_NONE) {
+        int r = std::rand() % 100;
+        Piece randomPiece = r < 35 ? Piece::PAWN : r < 50 ? Piece::KNIGHT : r < 65 ? Piece::BISHOP : r < 80 ? Piece::QUEEN : r < 95 ? Piece::KING : Piece::ROOK;
+        std::vector<Move> pieceMoves;
+        for (Move m : legalMoves) {
+            if (board->pieces[moveOrigin(m)] == randomPiece)
+                pieceMoves.push_back(m);
+        }
+        if (!pieceMoves.empty()) {
+            move = pieceMoves[std::rand() % pieceMoves.size()];
+        }
+    }
     board->doMove(&boardStack, move, board->hashAfter(move), &thread->nnue);
 
     return playRandomMoves(board, thread, remainingMoves - 1);


### PR DESCRIPTION
The following test used 512 neuron hidden layer networks for base vs. dev, each trained using ~300M positions:

```
Elo   | 13.23 +- 5.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.68 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5256 W: 1536 L: 1336 D: 2384
Penta | [58, 585, 1176, 717, 92]
https://chess.aronpetkovski.com/test/2977/
```

Bench: 2261984