### PR TITLE
Material draw detection

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1150,6 +1150,19 @@ bool Board::hasUpcomingRepetition(int ply) {
 // Checks for 2-fold repetition and rule50 draw
 bool Board::isDraw() {
 
+    // Check for material draw
+    int pieceCount = BB::popcount(byColor[Color::WHITE] | byColor[Color::BLACK]);
+    if (pieceCount == 2)
+        return true;
+    if (pieceCount == 3 && (byPiece[Piece::KNIGHT] || byPiece[Piece::BISHOP]))
+        return true;
+    if (pieceCount == 4) {
+        if (BB::popcount(byPiece[Piece::KNIGHT]) == 2)
+            return true;
+        if (BB::popcount(byPiece[Piece::BISHOP]) == 2 && (byPiece[Piece::BISHOP] & byColor[Color::WHITE]) && (byPiece[Piece::BISHOP] & byColor[Color::BLACK]))
+            return true;
+    }
+
     // The stack needs to go back far enough
     if (!stack->previous || !stack->previous->previous)
         return false;


### PR DESCRIPTION
STC
```
Elo   | 4.57 +- 2.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15342 W: 3525 L: 3323 D: 8494
Penta | [49, 1612, 4142, 1824, 44]
https://chess.aronpetkovski.com/test/3288/
```

LTC
```
Elo   | 4.25 +- 4.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.76 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3922 W: 882 L: 834 D: 2206
Penta | [4, 367, 1170, 417, 3]
https://chess.aronpetkovski.com/test/3294/
```

Bench: 2359201