### PR TITLE
50mr adjustment

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -43,7 +43,7 @@ Eval evaluate(Board* board, NNUE* nnue) {
 
     Eval eval = nnue->evaluate(board);
     eval = (eval * getMaterialScale(board)) / 1024;
-    // eval = eval * (220 - board->stack->rule50_ply) / 220;
+    eval = eval * (300 - board->stack->rule50_ply) / 300;
 
     eval = std::clamp((int) eval, (int) -EVAL_MATE_IN_MAX_PLY + 1, (int) EVAL_MATE_IN_MAX_PLY - 1);
     return eval;


### PR DESCRIPTION
```
Elo   | 0.90 +- 0.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.79 (-2.25, 2.89) [0.00, 3.00]
Games | N: 122510 W: 27144 L: 26827 D: 68539
Penta | [342, 14427, 31456, 14632, 398]
https://chess.aronpetkovski.com/test/3340/
```

Bench: 2425960