### PR TITLE
Simplify FP in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -649,20 +649,16 @@ movesLoop:
                     skipQuiets = true;
                 }
 
-                if (!board->stack->checkers) {
-                    // Futility pruning
-                    if (capture) {
-                        if (moveType(move) != MOVE_PROMOTION) {
-                            Piece capturedPiece = moveType(move) == MOVE_ENPASSANT ? Piece::PAWN : board->pieces[moveTarget(move)];
-                            if (lmrDepth < fpCaptDepth && eval + fpCaptBase + PIECE_VALUES[capturedPiece] + fpCaptFactor * lmrDepth <= alpha)
-                                continue;
-                        }
-                    }
-                    else {
-                        if (lmrDepth < fpDepth && eval + fpBase + fpFactor * lmrDepth <= alpha)
-                            skipQuiets = true;
-                    }
-                }
+                // Futility pruning
+                if (!capture && lmrDepth < fpDepth && eval + fpBase + fpFactor * lmrDepth <= alpha)
+                    skipQuiets = true;
+            }
+
+            // Futility pruning for captures
+            if (capture && moveType(move) != MOVE_PROMOTION) {
+                Piece capturedPiece = moveType(move) == MOVE_ENPASSANT ? Piece::PAWN : board->pieces[moveTarget(move)];
+                if (lmrDepth < fpCaptDepth && eval + fpCaptBase + PIECE_VALUES[capturedPiece] + fpCaptFactor * lmrDepth <= alpha)
+                    continue;
             }
 
             // History pruning


### PR DESCRIPTION
```
Elo   | 0.38 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52490 W: 11591 L: 11533 D: 29366
Penta | [117, 5930, 14110, 5954, 134]
https://chess.aronpetkovski.com/test/4010/
```

Easily passed non-regression bounds

Bench: 2167652