### PR TITLE
More LMR in pv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -747,7 +747,7 @@ movesLoop:
 
         // Very basic LMR: Late moves are being searched with less depth
         // Check if the move can exceed alpha
-        if (moveCount > lmrMcBase + lmrMcPv * pvNode && depth >= lmrMinDepth && (!capture || !ttPv)) {
+        if (moveCount > lmrMcBase + lmrMcPv * rootNode && depth >= lmrMinDepth && (!capture || !ttPv)) {
             int reducedDepth = newDepth - REDUCTIONS[!capture][depth][moveCount];
 
             if (!ttPv)


### PR DESCRIPTION
```
Elo   | 3.32 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23146 W: 5211 L: 4990 D: 12945
Penta | [54, 2612, 6040, 2793, 74]
https://chess.aronpetkovski.com/test/4380/
```

Bench: 2152679