### PR TITLE
Continuation correction history

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -11,6 +11,7 @@ TUNE_INT(pawnCorrectionFactor, 941, 10, 5000);
 TUNE_INT(nonPawnCorrectionFactor, 839, 10, 5000);
 TUNE_INT(minorCorrectionFactor, 667, 10, 5000);
 TUNE_INT(majorCorrectionFactor, 748, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 500, 10, 5000);
 TUNE_INT(correctionHistoryDivisor, 8945, 5000, 20000);
 
 void History::initHistory() {
@@ -26,22 +27,25 @@ void History::initHistory() {
     memset(nonPawnCorrectionHistory, 0, sizeof(nonPawnCorrectionHistory));
     memset(minorCorrectionHistory, 0, sizeof(minorCorrectionHistory));
     memset(majorCorrectionHistory, 0, sizeof(majorCorrectionHistory));
+    memset(continuationCorrectionHistory, 0, sizeof(continuationCorrectionHistory));
     memset(pawnHistory, -1000, sizeof(pawnHistory));
 }
 
-Eval History::correctStaticEval(Eval eval, Board* board) {
+Eval History::correctStaticEval(Eval eval, Board* board, SearchStack* searchStack) {
     int64_t pawnEntry = correctionHistory[board->stm][board->stack->pawnHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t nonPawnEntry = nonPawnCorrectionHistory[board->stm][Color::WHITE][board->stack->nonPawnHash[Color::WHITE] & (CORRECTION_HISTORY_SIZE - 1)] + nonPawnCorrectionHistory[board->stm][Color::BLACK][board->stack->nonPawnHash[Color::BLACK] & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t minorEntry = minorCorrectionHistory[board->stm][board->stack->minorHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t majorEntry = majorCorrectionHistory[board->stm][board->stack->majorHash & (CORRECTION_HISTORY_SIZE - 1)];
-    int64_t history = (pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor) / 1000;
+    int64_t contEntry = (searchStack - 1)->movedPiece != Piece::NONE ? *((searchStack - 1)->contCorrHist) : 0;
+
+    int64_t history = (pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor) / 1000;
 
     Eval adjustedEval = eval + (history * std::abs(history)) / correctionHistoryDivisor;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_MATE_IN_MAX_PLY + 1, (int)EVAL_MATE_IN_MAX_PLY - 1);
     return adjustedEval;
 }
 
-void History::updateCorrectionHistory(Board* board, int16_t bonus) {
+void History::updateCorrectionHistory(Board* board, SearchStack* searchStack, int16_t bonus) {
     // Pawn
     Eval scaledBonus = bonus - correctionHistory[board->stm][board->stack->pawnHash & (CORRECTION_HISTORY_SIZE - 1)] * std::abs(bonus) / CORRECTION_HISTORY_LIMIT;
     correctionHistory[board->stm][board->stack->pawnHash & (CORRECTION_HISTORY_SIZE - 1)] += scaledBonus;
@@ -57,6 +61,12 @@ void History::updateCorrectionHistory(Board* board, int16_t bonus) {
     minorCorrectionHistory[board->stm][board->stack->minorHash & (CORRECTION_HISTORY_SIZE - 1)] += scaledBonus;
     scaledBonus = bonus - majorCorrectionHistory[board->stm][board->stack->majorHash & (CORRECTION_HISTORY_SIZE - 1)] * std::abs(bonus) / CORRECTION_HISTORY_LIMIT;
     majorCorrectionHistory[board->stm][board->stack->majorHash & (CORRECTION_HISTORY_SIZE - 1)] += scaledBonus;
+
+    // Continuation
+    if ((searchStack - 1)->movedPiece != Piece::NONE) {
+        scaledBonus = bonus - *(searchStack - 1)->contCorrHist * std::abs(bonus) / CORRECTION_HISTORY_LIMIT;
+        *(searchStack - 1)->contCorrHist += scaledBonus;
+    }
 }
 
 int History::getHistory(Board* board, BoardStack* boardStack, SearchStack* searchStack, Move move, bool isCapture) {

--- a/src/history.h
+++ b/src/history.h
@@ -23,11 +23,12 @@ class History {
 public:
 
     int16_t continuationHistory[2][Piece::TOTAL][64][Piece::TOTAL * 64 * 2];
+    int16_t continuationCorrectionHistory[2][Piece::TOTAL][64];
 
     void initHistory();
 
-    Eval correctStaticEval(Eval eval, Board* board);
-    void updateCorrectionHistory(Board* board, int16_t bonus);
+    Eval correctStaticEval(Eval eval, Board* board, SearchStack* searchStack);
+    void updateCorrectionHistory(Board* board, SearchStack* searchStack, int16_t bonus);
 
     int getHistory(Board* board, BoardStack* boardStack, SearchStack* searchStack, Move move, bool isCapture);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -280,14 +280,14 @@ Eval Thread::qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta) {
     }
     else if (ttHit && ttEval != EVAL_NONE) {
         unadjustedEval = ttEval;
-        stack->staticEval = bestValue = history.correctStaticEval(unadjustedEval, board);
+        stack->staticEval = bestValue = history.correctStaticEval(unadjustedEval, board, stack);
 
         if (ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue < bestValue) || (ttFlag == TT_LOWERBOUND && ttValue > bestValue) || (ttFlag == TT_EXACTBOUND)))
             bestValue = ttValue;
     }
     else {
         unadjustedEval = evaluate(board, &nnue);
-        stack->staticEval = bestValue = history.correctStaticEval(unadjustedEval, board);
+        stack->staticEval = bestValue = history.correctStaticEval(unadjustedEval, board, stack);
         ttEntry->update(board->stack->hash, MOVE_NONE, 0, unadjustedEval, EVAL_NONE, ttPv, TT_NOBOUND);
     }
     futilityValue = stack->staticEval + qsFutilityOffset;
@@ -348,6 +348,7 @@ movesLoopQsearch:
         stack->move = move;
         stack->movedPiece = board->pieces[origin];
         stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+        stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target];
 
         playedQuiet |= move != ttMove && !capture;
 
@@ -476,14 +477,14 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     }
     else if (ttHit) {
         unadjustedEval = ttEval != EVAL_NONE ? ttEval : evaluate(board, &nnue);
-        eval = stack->staticEval = history.correctStaticEval(unadjustedEval, board);
+        eval = stack->staticEval = history.correctStaticEval(unadjustedEval, board, stack);
 
         if (ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue < eval) || (ttFlag == TT_LOWERBOUND && ttValue > eval) || (ttFlag == TT_EXACTBOUND)))
             eval = ttValue;
     }
     else {
         unadjustedEval = evaluate(board, &nnue);
-        eval = stack->staticEval = history.correctStaticEval(unadjustedEval, board);
+        eval = stack->staticEval = history.correctStaticEval(unadjustedEval, board, stack);
 
         ttEntry->update(board->stack->hash, MOVE_NONE, 0, unadjustedEval, EVAL_NONE, ttPv, TT_NOBOUND);
     }
@@ -536,6 +537,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
         stack->move = MOVE_NULL;
         stack->movedPiece = Piece::NONE;
         stack->contHist = history.continuationHistory[board->stm][0][0];
+        stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][0][0];
         int R = nmpRedBase + depth / nmpDepthDiv + std::min((eval - beta) / nmpDivisor, nmpMin);
 
         board->doNullMove(&boardStack);
@@ -588,6 +590,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
             stack->move = move;
             stack->movedPiece = board->pieces[origin];
             stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+            stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target];
             board->doMove(&boardStack, move, newHash, &nnue);
 
             Eval value = -qsearch<NON_PV_NODE>(board, stack + 1, -probCutBeta, -probCutBeta + 1);
@@ -734,6 +737,7 @@ movesLoop:
         stack->move = move;
         stack->movedPiece = board->pieces[origin];
         stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+        stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target];
 
         moveCount++;
         searchData.nodesSearched++;
@@ -872,7 +876,7 @@ movesLoop:
     // Adjust correction history
     if (!board->stack->checkers && (bestMove == MOVE_NONE || !board->isCapture(bestMove)) && (!failHigh || bestValue > stack->staticEval) && (!failLow || bestValue <= stack->staticEval)) {
         int bonus = std::clamp((int)(bestValue - stack->staticEval) * depth * correctionHistoryFactor / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
-        history.updateCorrectionHistory(board, bonus);
+        history.updateCorrectionHistory(board, stack, bonus);
     }
 
     assert(bestValue > -EVAL_INFINITE && bestValue < EVAL_INFINITE);

--- a/src/types.h
+++ b/src/types.h
@@ -101,4 +101,5 @@ struct SearchStack {
     Move killer;
 
     int16_t* contHist;
+    int16_t* contCorrHist;
 };


### PR DESCRIPTION
```
Elo   | 2.12 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 43868 W: 9917 L: 9649 D: 24302
Penta | [136, 5026, 11359, 5260, 153]
https://chess.aronpetkovski.com/test/4418/
```

Bench: 2129505