### PR TITLE
Always do LMR in cutNodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -753,7 +753,7 @@ movesLoop:
 
         // Very basic LMR: Late moves are being searched with less depth
         // Check if the move can exceed alpha
-        if (moveCount > lmrMcBase + lmrMcPv * rootNode && depth >= lmrMinDepth && (!capture || !ttPv)) {
+        if (moveCount > lmrMcBase + lmrMcPv * rootNode && depth >= lmrMinDepth && (!capture || !ttPv || cutNode)) {
             int reducedDepth = newDepth - REDUCTIONS[!capture][depth][moveCount];
 
             if (!ttPv)


### PR DESCRIPTION
```
Elo   | 3.67 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20266 W: 4635 L: 4421 D: 11210
Penta | [56, 2255, 5299, 2465, 58]
https://chess.aronpetkovski.com/test/4570/
```

Bench: 2167568