### PR TITLE
Skip LMR re-search if tt entry deems it unnecessary

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -777,7 +777,7 @@ movesLoop:
             bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth);
             newDepth += doDeeperSearch - doShallowerSearch;
 
-            if (value > alpha && reducedDepth < newDepth) {
+            if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - 4 >= newDepth && (ttFlag & TT_UPPERBOUND))) {
                 value = -search<NON_PV_NODE>(board, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);
 
                 if (!capture) {


### PR DESCRIPTION
STC
```
Elo   | -0.17 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49302 W: 11098 L: 11122 D: 27082
Penta | [118, 5314, 13796, 5320, 103]
https://chess.aronpetkovski.com/test/4870/
```

LTC
```
Elo   | 1.75 +- 1.39 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50504 W: 11703 L: 11449 D: 27352
Penta | [23, 5084, 14786, 5334, 25]
https://chess.aronpetkovski.com/test/4875/
```

Bench: 1927024