### PR TITLE
Add 6th ply conthist to history score

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -113,6 +113,9 @@ int History::getContinuationHistory(SearchStack* stack, Color side, Piece piece,
 
     if ((stack - 4)->movedPiece != Piece::NONE)
         score += (stack - 4)->contHist[pieceTo];
+    
+    if ((stack - 6)->movedPiece != Piece::NONE)
+        score += (stack - 6)->contHist[pieceTo] / 2;
 
     return score;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -943,7 +943,7 @@ void Thread::iterativeDeepening() {
 
     int bestMoveStability = 0;
 
-    constexpr int STACK_OVERHEAD = 4;
+    constexpr int STACK_OVERHEAD = 6;
     SearchStack stackList[MAX_PLY + STACK_OVERHEAD];
     SearchStack* stack = &stackList[STACK_OVERHEAD];
 
@@ -1165,7 +1165,7 @@ void Thread::tdatagen() {
 
     Eval previousValue = EVAL_NONE;
 
-    constexpr int STACK_OVERHEAD = 4;
+    constexpr int STACK_OVERHEAD = 6;
     SearchStack stackList[MAX_PLY + STACK_OVERHEAD];
     SearchStack* stack = &stackList[STACK_OVERHEAD];
 


### PR DESCRIPTION
```
Elo   | 3.30 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23452 W: 5358 L: 5135 D: 12959
Penta | [62, 2680, 6036, 2869, 79]
https://chess.aronpetkovski.com/test/4932/
```

Bench: 1775407