### PR TITLE
Increase minimum and maximum NMP reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,10 +73,10 @@ TUNE_INT(rfpFactor, 75, 1, 250);
 TUNE_INT_DISABLED(razoringDepth, 5, 2, 20);
 TUNE_INT(razoringFactor, 204, 1, 1000);
 
-TUNE_INT_DISABLED(nmpRedBase, 3, 1, 5);
+TUNE_INT_DISABLED(nmpRedBase, 4, 1, 5);
 TUNE_INT_DISABLED(nmpDepthDiv, 3, 1, 6);
-TUNE_INT_DISABLED(nmpMin, 3, 1, 10);
-TUNE_INT(nmpDivisor, 24, 10, 1000);
+TUNE_INT_DISABLED(nmpMin, 4, 1, 10);
+TUNE_INT(nmpDivisor, 60, 10, 1000);
 
 TUNE_INT(probCutBetaOffset, 191, 1, 500);
 TUNE_INT_DISABLED(probCutDepth, 5, 1, 15);


### PR DESCRIPTION
```
Elo   | 1.53 +- 1.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 76576 W: 17169 L: 16832 D: 42575
Penta | [205, 8821, 19886, 9184, 192]
https://chess.aronpetkovski.com/test/5021/
```

Bench: 1810929