### PR TITLE
Less negative extensions in PV nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -715,7 +715,7 @@ movesLoop:
                 return std::min(singularBeta, EVAL_MATE_IN_MAX_PLY - 1);
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
             else if (ttValue >= beta)
-                extension = -2;
+                extension = -2 + pvNode;
             // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low, so reduce
             else if (cutNode)
                 extension = -2;


### PR DESCRIPTION
```
Elo   | 0.78 +- 0.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.17 (-2.25, 2.89) [0.00, 3.00]
Games | N: 146904 W: 33262 L: 32934 D: 80708
Penta | [354, 16862, 38724, 17126, 386]
https://chess.aronpetkovski.com/test/5056/
```

Bench: 1742234