### PR TITLE
Remove check extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -748,9 +748,6 @@ movesLoop:
         searchData.nodesSearched++;
         board->doMove(&boardStack, move, newHash, &nnue);
 
-        if (doExtensions && extension == 0 && board->stack->checkers)
-            extension = 1;
-
         Eval value = 0;
         int newDepth = depth - 1 + extension;
 


### PR DESCRIPTION
```
Elo   | 2.66 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31168 W: 7132 L: 6893 D: 17143
Penta | [79, 3586, 8033, 3789, 97]
https://chess.aronpetkovski.com/test/5243/
```

Bench: 1561918