### PR TITLE
Introduce triple extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -708,6 +708,8 @@ movesLoop:
                 if (!pvNode && singularValue + doubleExtensionMargin < singularBeta) {
                     extension = 2;
                     depth += depth < doubleExtensionDepthIncrease;
+                    if (!board->isCapture(move) && singularValue + 100 < singularBeta)
+                        extension = 3;
                 }
             }
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node


### PR DESCRIPTION
```
Elo   | 2.68 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 30828 W: 7064 L: 6826 D: 16938
Penta | [76, 3494, 8044, 3716, 84]
https://chess.aronpetkovski.com/test/5261/
```

Bench: 1574339