### PR TITLE
Reduce checking moves less

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -758,6 +758,9 @@ movesLoop:
         if (moveCount > lmrMcBase + lmrMcPv * rootNode && depth >= lmrMinDepth && (!capture || !ttPv || cutNode)) {
             int reducedDepth = newDepth - REDUCTIONS[!capture][depth][moveCount];
 
+            if (board->stack->checkers)
+                reducedDepth++;
+
             if (!ttPv)
                 reducedDepth--;
 


### PR DESCRIPTION
```
Elo   | 1.96 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49396 W: 11257 L: 10979 D: 27160
Penta | [129, 5619, 12933, 5879, 138]
https://chess.aronpetkovski.com/test/5262/
```

Bench: 1581905