### PR TITLE
Less NMP depending on static eval and depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -525,6 +525,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     // Null move pruning
     if (!pvNode
         && eval >= beta
+        && eval >= stack->staticEval
         && stack->staticEval + 30 * depth - 150 >= beta
         && std::abs(beta) < EVAL_MATE_IN_MAX_PLY
         && !excluded

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -525,6 +525,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     // Null move pruning
     if (!pvNode
         && eval >= beta
+        && stack->staticEval + 30 * depth - 150 >= beta
         && std::abs(beta) < EVAL_MATE_IN_MAX_PLY
         && !excluded
         && (stack - 1)->movedPiece != Piece::NONE

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -524,10 +524,8 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
     // Null move pruning
     if (!pvNode
-        && eval >= stack->staticEval
         && eval >= beta
-        && beta > -EVAL_MATE_IN_MAX_PLY
-        && beta < EVAL_MATE_IN_MAX_PLY
+        && std::abs(beta) < EVAL_MATE_IN_MAX_PLY
         && !excluded
         && (stack - 1)->movedPiece != Piece::NONE
         && depth >= 3


### PR DESCRIPTION
```
Elo   | 3.60 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.51 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18030 W: 4166 L: 3979 D: 9885
Penta | [45, 2036, 4673, 2209, 52]
https://chess.aronpetkovski.com/test/5354/
```

Bench: 1579657