### PR TITLE
Don't update quiet history based on static eval in excluded searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -504,7 +504,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     }
 
     // Adjust quiet history based on how much the previous move changed static eval
-    if ((stack - 1)->movedPiece != Piece::NONE && !(stack - 1)->capture && !(stack - 1)->inCheck && stack->ply > 1) {
+    if (!excluded && (stack - 1)->movedPiece != Piece::NONE && !(stack - 1)->capture && !(stack - 1)->inCheck && stack->ply > 1) {
         int bonus = std::clamp(staticHistoryFactor * int(stack->staticEval + (stack - 1)->staticEval) / 10, staticHistoryMin, staticHistoryMax);
         history.updateQuietHistory((stack - 1)->move, flip(board->stm), board, board->stack->previous, bonus);
     }


### PR DESCRIPTION
```
Elo   | 3.33 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15020 W: 3407 L: 3263 D: 8350
Penta | [33, 1662, 3983, 1792, 40]
https://chess.aronpetkovski.com/test/5472/
```

Bench: 1662115