### PR TITLE
Scale history updates depending on how many times a move was searched

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -163,31 +163,31 @@ void History::updateSingleCaptureHistory(Board* board, Move move, int16_t bonus)
     *captHistScore += scaledBonus;
 }
 
-void History::updateCaptureHistory(Board* board, Move move, int16_t bonus, Move* captureMoves, int captureMoveCount) {
+void History::updateCaptureHistory(Board* board, Move move, int moveSearchCount, int16_t bonus, Move* captureMoves, int* captureSearchCount, int captureMoveCount) {
     if (board->isCapture(move)) {
-        updateSingleCaptureHistory(board, move, bonus);
+        updateSingleCaptureHistory(board, move, bonus * moveSearchCount);
     }
 
     for (int i = 0; i < captureMoveCount; i++) {
         Move cMove = captureMoves[i];
         if (move == cMove) continue;
-        updateSingleCaptureHistory(board, cMove, -bonus);
+        updateSingleCaptureHistory(board, cMove, -bonus * captureSearchCount[i]);
     }
 }
 
-void History::updateQuietHistories(Board* board, BoardStack* boardStack, SearchStack* stack, Move move, int16_t bonus, Move* quietMoves, int quietMoveCount) {
+void History::updateQuietHistories(Board* board, BoardStack* boardStack, SearchStack* stack, Move move, int moveSearchCount, int16_t bonus, Move* quietMoves, int* quietSearchCount, int quietMoveCount) {
     // Increase stats for this move
-    updateQuietHistory(move, board->stm, board, boardStack, bonus);
-    updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(move)], move, bonus);
-    updatePawnHistory(board, move, bonus);
+    updateQuietHistory(move, board->stm, board, boardStack, bonus * moveSearchCount);
+    updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(move)], move, bonus * moveSearchCount);
+    updatePawnHistory(board, move, bonus * moveSearchCount);
 
     // Decrease stats for all other quiets
     for (int i = 0; i < quietMoveCount; i++) {
         Move qMove = quietMoves[i];
         if (move == qMove) continue;
-        updateQuietHistory(qMove, board->stm, board, boardStack, -bonus);
-        updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(qMove)], qMove, -bonus);
-        updatePawnHistory(board, qMove, -bonus);
+        updateQuietHistory(qMove, board->stm, board, boardStack, -bonus * quietSearchCount[i]);
+        updateContinuationHistory(stack, board->stm, board->pieces[moveOrigin(qMove)], qMove, -bonus * quietSearchCount[i]);
+        updatePawnHistory(board, qMove, -bonus * quietSearchCount[i]);
     }
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -43,9 +43,9 @@ public:
 
     int16_t* getCaptureHistory(Board* board, Move move);
     void updateSingleCaptureHistory(Board* board, Move move, int16_t bonus);
-    void updateCaptureHistory(Board* board, Move move, int16_t bonus, Move* captureMoves, int captureMoveCount);
+    void updateCaptureHistory(Board* board, Move move, int moveSearchCount, int16_t bonus, Move* captureMoves, int* captureSearchCount, int captureMoveCount);
 
-    void updateQuietHistories(Board* board, BoardStack* boardStack, SearchStack* stack, Move move, int16_t bonus, Move* quietMoves, int quietMoveCount);
+    void updateQuietHistories(Board* board, BoardStack* boardStack, SearchStack* stack, Move move, int moveSearchCount, int16_t bonus, Move* quietMoves, int* quietSearchCount, int quietMoveCount);
 
     Move getCounterMove(Move move);
     void setCounterMove(Move move, Move counter);


### PR DESCRIPTION
```
Elo   | 2.12 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44466 W: 10198 L: 9927 D: 24341
Penta | [115, 5230, 11277, 5491, 120]
https://chess.aronpetkovski.com/test/5493/
```

Idea by CJ in the Alexandria search rewrite

Bench: 1576573