### PR TITLE
More aggressive triple extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -710,7 +710,7 @@ movesLoop:
                 if (!pvNode && singularValue + doubleExtensionMargin < singularBeta) {
                     extension = 2;
                     depth += depth < doubleExtensionDepthIncrease;
-                    if (!board->isCapture(move) && singularValue + 100 < singularBeta)
+                    if (!board->isCapture(move) && singularValue + 60 < singularBeta)
                         extension = 3;
                 }
             }


### PR DESCRIPTION
```
Elo   | 0.61 +- 0.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.71 (-2.25, 2.89) [0.00, 3.00]
Games | N: 237722 W: 53824 L: 53405 D: 130493
Penta | [624, 27673, 61874, 28040, 650]
https://chess.aronpetkovski.com/test/5572/
```

Bench: 1609436