### PR TITLE
Initialise aspiration window delta quadratically using an average of previous scores

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -853,6 +853,8 @@ movesLoop:
                 }
             }
 
+            rootMove->meanScore = rootMove->meanScore == EVAL_NONE ? value : (rootMove->meanScore + value) / 2;
+
             if (moveCount == 1 || value > alpha) {
                 rootMove->value = value;
                 rootMove->depth = searchData.rootDepth;
@@ -1015,7 +1017,10 @@ void Thread::iterativeDeepening() {
 
             if (depth >= aspirationWindowMinDepth) {
                 // Set up interval for the start of this aspiration window
-                delta = aspirationWindowDelta;
+                if (rootMoves[0].meanScore == EVAL_NONE)
+                    delta = aspirationWindowDelta;
+                else
+                    delta = 10 + rootMoves[0].meanScore * rootMoves[0].meanScore / 12000;
                 alpha = std::max(previousValue - delta, -EVAL_INFINITE);
                 beta = std::min(previousValue + delta, (int)EVAL_INFINITE);
             }

--- a/src/thread.h
+++ b/src/thread.h
@@ -15,6 +15,7 @@
 
 struct RootMove {
     Eval value = -EVAL_INFINITE;
+    Eval meanScore = EVAL_NONE;
     int depth = 0;
     int selDepth = 0;
     Move move = MOVE_NULL;


### PR DESCRIPTION
```
Elo   | 2.32 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38096 W: 8725 L: 8471 D: 20900
Penta | [94, 4357, 9893, 4609, 95]
https://chess.aronpetkovski.com/test/5833/
```

Bench: 1825184