### PR TITLE
Save multicut in TT

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -717,8 +717,11 @@ movesLoop:
                 }
             }
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node
-            else if (singularBeta >= beta)
-                return std::min(singularBeta, EVAL_MATE_IN_MAX_PLY - 1);
+            else if (singularBeta >= beta) {
+                Eval value = std::min(singularBeta, EVAL_MATE_IN_MAX_PLY - 1);
+                ttEntry->update(board->stack->hash, ttMove, depth, unadjustedEval, value, ttPv, TT_LOWERBOUND);
+                return value;
+            }
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
             else if (ttValue >= beta)
                 extension = -2 + pvNode;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -719,7 +719,7 @@ movesLoop:
             // Multicut: If we beat beta, that means there's likely more moves that beat beta and we can skip this node
             else if (singularBeta >= beta) {
                 Eval value = std::min(singularBeta, EVAL_MATE_IN_MAX_PLY - 1);
-                ttEntry->update(board->stack->hash, ttMove, depth, unadjustedEval, value, ttPv, TT_LOWERBOUND);
+                ttEntry->update(board->stack->hash, ttMove, singularDepth, unadjustedEval, value, ttPv, TT_LOWERBOUND);
                 return value;
             }
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth


### PR DESCRIPTION
```
Elo   | 1.27 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.83 (-2.25, 2.89) [0.00, 3.00]
Games | N: 71694 W: 16534 L: 16271 D: 38889
Penta | [165, 8328, 18610, 8567, 177]
https://chess.aronpetkovski.com/test/5850/
```

Bench: 1857369