### PR TITLE
Lower singular beta for nodes that used to be on the PV

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -708,7 +708,7 @@ movesLoop:
             && std::abs(ttValue) < EVAL_MATE_IN_MAX_PLY
             && ttDepth >= depth - 3
             ) {
-            Eval singularBeta = ttValue - depth;
+            Eval singularBeta = ttValue - (1 + (ttPv && !pvNode)) * depth;
             int singularDepth = (depth - 1) / 2;
 
             stack->excludedMove = move;


### PR DESCRIPTION
STC
```
Elo   | 5.21 +- 3.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.13 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9938 W: 2334 L: 2185 D: 5419
Penta | [19, 1146, 2507, 1261, 36]
https://chess.aronpetkovski.com/test/6088/
```

LTC
```
Elo   | 5.34 +- 3.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.50 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10536 W: 2577 L: 2415 D: 5544
Penta | [5, 1130, 2840, 1284, 9]
https://chess.aronpetkovski.com/test/6089/
```

Bench: 1835791