### PR TITLE
Lower minimum depth for extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -701,7 +701,7 @@ movesLoop:
         bool doExtensions = !rootNode && stack->ply < searchData.rootDepth * 2;
         int extension = 0;
         if (doExtensions
-            && depth >= 7
+            && depth >= 6
             && move == ttMove
             && !excluded
             && (ttFlag & TT_LOWERBOUND)


### PR DESCRIPTION
STC
```
Elo   | 1.44 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.05 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31708 W: 7363 L: 7232 D: 17113
Penta | [80, 3681, 8198, 3818, 77]
https://chess.aronpetkovski.com/test/6090/
```

LTC
```
Elo   | 2.04 +- 2.18 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.54 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22850 W: 5420 L: 5286 D: 12144
Penta | [9, 2561, 6152, 2693, 10]
https://chess.aronpetkovski.com/test/6105/
```

Bench: 1886365