### PR TITLE
Switch to a linear correction history formula

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,11 +7,11 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(pawnCorrectionFactor, 506, 10, 5000);
-TUNE_INT(nonPawnCorrectionFactor, 500, 10, 5000);
-TUNE_INT(minorCorrectionFactor, 338, 10, 5000);
-TUNE_INT(majorCorrectionFactor, 272, 10, 5000);
-TUNE_INT(continuationCorrectionFactor, 488, 10, 5000);
+TUNE_INT(pawnCorrectionFactor, 5060, 10, 5000);
+TUNE_INT(nonPawnCorrectionFactor, 5000, 10, 5000);
+TUNE_INT(minorCorrectionFactor, 3380, 10, 5000);
+TUNE_INT(majorCorrectionFactor, 2720, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 4880, 10, 5000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,11 +7,11 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(pawnCorrectionFactor, 2530, 10, 5000);
-TUNE_INT(nonPawnCorrectionFactor, 2500, 10, 5000);
-TUNE_INT(minorCorrectionFactor, 1690, 10, 5000);
-TUNE_INT(majorCorrectionFactor, 1360, 10, 5000);
-TUNE_INT(continuationCorrectionFactor, 2440, 10, 5000);
+TUNE_INT(pawnCorrectionFactor, 5060, 10, 5000);
+TUNE_INT(nonPawnCorrectionFactor, 5000, 10, 5000);
+TUNE_INT(minorCorrectionFactor, 3380, 10, 5000);
+TUNE_INT(majorCorrectionFactor, 2720, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 4880, 10, 5000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));
@@ -39,7 +39,7 @@ Eval History::correctStaticEval(Eval eval, Board* board, SearchStack* searchStac
 
     int64_t history = pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor;
 
-    Eval adjustedEval = eval + history / 131072;
+    Eval adjustedEval = eval + history / 65536;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_MATE_IN_MAX_PLY + 1, (int)EVAL_MATE_IN_MAX_PLY - 1);
     return adjustedEval;
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,11 +7,11 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(pawnCorrectionFactor, 5060, 10, 5000);
-TUNE_INT(nonPawnCorrectionFactor, 5000, 10, 5000);
-TUNE_INT(minorCorrectionFactor, 3380, 10, 5000);
-TUNE_INT(majorCorrectionFactor, 2720, 10, 5000);
-TUNE_INT(continuationCorrectionFactor, 4880, 10, 5000);
+TUNE_INT(pawnCorrectionFactor, 2530, 10, 5000);
+TUNE_INT(nonPawnCorrectionFactor, 2500, 10, 5000);
+TUNE_INT(minorCorrectionFactor, 1690, 10, 5000);
+TUNE_INT(majorCorrectionFactor, 1360, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 2440, 10, 5000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,12 +7,11 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(pawnCorrectionFactor, 843, 10, 5000);
-TUNE_INT(nonPawnCorrectionFactor, 833, 10, 5000);
-TUNE_INT(minorCorrectionFactor, 563, 10, 5000);
-TUNE_INT(majorCorrectionFactor, 454, 10, 5000);
-TUNE_INT(continuationCorrectionFactor, 814, 10, 5000);
-TUNE_INT(correctionHistoryDivisor, 11016, 5000, 20000);
+TUNE_INT(pawnCorrectionFactor, 506, 10, 5000);
+TUNE_INT(nonPawnCorrectionFactor, 500, 10, 5000);
+TUNE_INT(minorCorrectionFactor, 338, 10, 5000);
+TUNE_INT(majorCorrectionFactor, 272, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 488, 10, 5000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));
@@ -38,9 +37,9 @@ Eval History::correctStaticEval(Eval eval, Board* board, SearchStack* searchStac
     int64_t majorEntry = majorCorrectionHistory[board->stm][board->stack->majorHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t contEntry = (searchStack - 1)->movedPiece != Piece::NONE ? *((searchStack - 1)->contCorrHist) : 0;
 
-    int64_t history = (pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor) / 1000;
+    int64_t history = pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor;
 
-    Eval adjustedEval = eval + (history * std::abs(history)) / correctionHistoryDivisor;
+    Eval adjustedEval = eval + history / 131072;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_MATE_IN_MAX_PLY + 1, (int)EVAL_MATE_IN_MAX_PLY - 1);
     return adjustedEval;
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "3.0.4";
+constexpr auto VERSION = "3.0.5";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 3.74 +- 2.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19700 W: 4743 L: 4531 D: 10426
Penta | [42, 2213, 5135, 2411, 49]
https://chess.aronpetkovski.com/test/6519/
```

LTC
```
Elo   | 5.50 +- 3.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.08 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8272 W: 2072 L: 1941 D: 4259
Penta | [1, 862, 2279, 993, 1]
https://chess.aronpetkovski.com/test/6520/
```

VLTC
```
Elo   | 5.68 +- 4.94 (95%)
SPRT  | 80.0+0.80s Threads=1 Hash=128MB
LLR   | 1.09 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4100 W: 1073 L: 1006 D: 2021
Penta | [0, 410, 1163, 477, 0]
https://chess.aronpetkovski.com/test/6526/
```

Bench: 2252761