### PR TITLE
Larger correction factors

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,11 +7,11 @@
 #include "evaluation.h"
 #include "spsa.h"
 
-TUNE_INT(pawnCorrectionFactor, 5060, 10, 5000);
-TUNE_INT(nonPawnCorrectionFactor, 5000, 10, 5000);
-TUNE_INT(minorCorrectionFactor, 3380, 10, 5000);
-TUNE_INT(majorCorrectionFactor, 2720, 10, 5000);
-TUNE_INT(continuationCorrectionFactor, 4880, 10, 5000);
+TUNE_INT(pawnCorrectionFactor, 5566, 10, 5000);
+TUNE_INT(nonPawnCorrectionFactor, 5500, 10, 5000);
+TUNE_INT(minorCorrectionFactor, 3718, 10, 5000);
+TUNE_INT(majorCorrectionFactor, 2992, 10, 5000);
+TUNE_INT(continuationCorrectionFactor, 5368, 10, 5000);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "3.0.5";
+constexpr auto VERSION = "3.0.6";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | -0.56 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34924 W: 8168 L: 8224 D: 18532
Penta | [78, 4150, 9069, 4080, 85]
https://chess.aronpetkovski.com/test/6527/
```

LTC
```
Elo   | 3.33 +- 2.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.66 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12310 W: 2994 L: 2876 D: 6440
Penta | [5, 1340, 3348, 1456, 6]
https://chess.aronpetkovski.com/test/6529/
```

Bench: 2085213