### PR TITLE
Fix pawn history fill

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -27,7 +27,15 @@ void History::initHistory() {
     memset(minorCorrectionHistory, 0, sizeof(minorCorrectionHistory));
     memset(majorCorrectionHistory, 0, sizeof(majorCorrectionHistory));
     memset(continuationCorrectionHistory, 0, sizeof(continuationCorrectionHistory));
-    memset(pawnHistory, -1000, sizeof(pawnHistory));
+    for (int i = 0; i < PAWN_HISTORY_SIZE; i++) {
+        for (int j = 0; j < 2; j++) {
+            for (int k = 0; k < Piece::TOTAL; k++) {
+                for (int l = 0; l < 64; l++) {
+                    pawnHistory[i][j][k][l] = -1000;
+                }
+            }
+        }
+    }
 }
 
 Eval History::correctStaticEval(Eval eval, Board* board, SearchStack* searchStack) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "3.0.16";
+constexpr auto VERSION = "3.0.17";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 0.22 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.52 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19218 W: 4691 L: 4679 D: 9848
Penta | [65, 2305, 4860, 2311, 68]
https://chess.aronpetkovski.com/test/7229/
```

Bench: 1967933