### PR TITLE
Reduce more depending on the amount of correction

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -38,16 +38,18 @@ void History::initHistory() {
     }
 }
 
-Eval History::correctStaticEval(Eval eval, Board* board, SearchStack* searchStack) {
+Eval History::getCorrectionValue(Board* board, SearchStack* searchStack) {
     int64_t pawnEntry = correctionHistory[board->stm][board->stack->pawnHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t nonPawnEntry = nonPawnCorrectionHistory[board->stm][Color::WHITE][board->stack->nonPawnHash[Color::WHITE] & (CORRECTION_HISTORY_SIZE - 1)] + nonPawnCorrectionHistory[board->stm][Color::BLACK][board->stack->nonPawnHash[Color::BLACK] & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t minorEntry = minorCorrectionHistory[board->stm][board->stack->minorHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t majorEntry = majorCorrectionHistory[board->stm][board->stack->majorHash & (CORRECTION_HISTORY_SIZE - 1)];
     int64_t contEntry = (searchStack - 1)->movedPiece != Piece::NONE ? *((searchStack - 1)->contCorrHist) : 0;
 
-    int64_t history = pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor;
+    return pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor;
+}
 
-    Eval adjustedEval = eval + history / 65536;
+Eval History::correctStaticEval(Eval eval, Eval correctionValue) {
+    Eval adjustedEval = eval + correctionValue / 65536;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_TBWIN_IN_MAX_PLY + 1, (int)EVAL_TBWIN_IN_MAX_PLY - 1);
     return adjustedEval;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -27,7 +27,8 @@ public:
 
     void initHistory();
 
-    Eval correctStaticEval(Eval eval, Board* board, SearchStack* searchStack);
+    Eval getCorrectionValue(Board* board, SearchStack* searchStack);
+    Eval correctStaticEval(Eval eval, Eval correctionValue);
     void updateCorrectionHistory(Board* board, SearchStack* searchStack, int16_t bonus);
 
     int getHistory(Board* board, BoardStack* boardStack, SearchStack* searchStack, Move move, bool isCapture);

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "3.0.18";
+constexpr auto VERSION = "3.0.19";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.71 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64590 W: 15839 L: 15522 D: 33229
Penta | [233, 7469, 16589, 7756, 248]
https://chess.aronpetkovski.com/test/7283/
```

Bench: 2289996