### PR TITLE
Fix tablebase probing during games

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -418,7 +418,6 @@ void setoption(std::string line) {
 
     if (name == "SyzygyPath") {
         std::string path = UCI::Options.syzygyPath.value;
-        std::cout << path << std::endl;
         tb_init(path.c_str());
         if (!TB_LARGEST)
             std::cout << "info string Tablebases failed to load" << std::endl;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.0";
+constexpr auto VERSION = "4.0.1";
 
 template<int... Is>
 struct seq { };
@@ -124,9 +124,17 @@ namespace UCI {
             ""
         };
 
+        UCIOption<UCI_SPIN> syzygyProbeLimit = {
+            "SyzygyProbeLimit",
+            7,
+            7,
+            0,
+            7
+        };
+
         template <typename Func>
         void forEach(Func&& f) {
-            auto optionsTuple = std::make_tuple(&hash, &threads, &multiPV, &moveOverhead, &chess960, &ponder, &datagen, &minimal, &syzygyPath);
+            auto optionsTuple = std::make_tuple(&hash, &threads, &multiPV, &moveOverhead, &chess960, &ponder, &datagen, &minimal, &syzygyPath, &syzygyProbeLimit);
             for_each_in_tuple(optionsTuple, f);
         }
     };


### PR DESCRIPTION
```
Elo   | 2.30 +- 1.83 (95%)
SPRT  | N=20000 Threads=1 Hash=16MB
LLR   | 1.67 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8902 W: 2675 L: 2616 D: 3611
Penta | [12, 217, 3925, 294, 3]
https://chess.aronpetkovski.com/test/7364/
```

Bench: 2381969