### PR TITLE
Earlier LMR if there's a TT move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -829,7 +829,7 @@ movesLoop:
 
         // Very basic LMR: Late moves are being searched with less depth
         // Check if the move can exceed alpha
-        if (moveCount > lmrMcBase + lmrMcPv * rootNode && depth >= lmrMinDepth && (!capture || !ttPv || cutNode)) {
+        if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth && (!capture || !ttPv || cutNode)) {
             int reducedDepth = newDepth - REDUCTIONS[!capture][depth][moveCount];
 
             if (board->stack->checkers)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.1";
+constexpr auto VERSION = "4.0.2";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.72 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64802 W: 15956 L: 15636 D: 33210
Penta | [224, 7636, 16391, 7896, 254]
https://chess.aronpetkovski.com/test/7380/
```

Bench: 2041995