### PR TITLE
Give post-lmr boni based on the depth that beat alpha

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -880,7 +880,7 @@ movesLoop:
                     quietSearchCount[quietMoveCount]++;
 
                 if (!capture) {
-                    int bonus = std::min(lmrPassBonusBase + lmrPassBonusFactor * depth, lmrPassBonusMax);
+                    int bonus = std::min(lmrPassBonusBase + lmrPassBonusFactor * (value > alpha ? depth : reducedDepth), lmrPassBonusMax);
                     history.updateContinuationHistory(stack, flip(board->stm), stack->movedPiece, move, bonus);
                 }
             }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.11";
+constexpr auto VERSION = "4.0.12";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.98 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49828 W: 12206 L: 11922 D: 25700
Penta | [173, 5766, 12773, 6008, 194]
https://chess.aronpetkovski.com/test/7992/
```
LTC
```
Elo   | 2.97 +- 2.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.22 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19050 W: 4655 L: 4492 D: 9903
Penta | [21, 2039, 5239, 2208, 18]
https://chess.aronpetkovski.com/test/8004/
```

Bench: 2501627