### PR TITLE
Prevent false mate/TB scores from qsearch pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,11 +335,11 @@ movesLoopQsearch:
     while ((move = movegen.nextMove()) != MOVE_NONE) {
 
         bool capture = board->isCapture(move);
-        if (!capture && playedQuiet)
+        if (!capture && playedQuiet && bestValue > -EVAL_TBWIN_IN_MAX_PLY)
             continue;
 
         if (futilityValue > -EVAL_INFINITE) { // Only prune when not in check
-            if (bestValue >= -EVAL_TBWIN_IN_MAX_PLY
+            if (bestValue > -EVAL_TBWIN_IN_MAX_PLY
                 && futilityValue <= alpha
                 && !SEE(board, move, 1)
                 ) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -338,11 +338,8 @@ movesLoopQsearch:
         if (!capture && playedQuiet && bestValue > -EVAL_TBWIN_IN_MAX_PLY)
             continue;
 
-        if (futilityValue > -EVAL_INFINITE) { // Only prune when not in check
-            if (bestValue > -EVAL_TBWIN_IN_MAX_PLY
-                && futilityValue <= alpha
-                && !SEE(board, move, 1)
-                ) {
+        if (futilityValue > -EVAL_INFINITE && bestValue > -EVAL_TBWIN_IN_MAX_PLY) { // Only prune when not in check
+            if (futilityValue <= alpha && !SEE(board, move, 1)) {
                 bestValue = std::max(bestValue, futilityValue);
                 continue;
             }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.12";
+constexpr auto VERSION = "4.0.13";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | -2.20 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.30 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 19726 W: 4724 L: 4849 D: 10153
Penta | [82, 2330, 5138, 2257, 56]
https://chess.aronpetkovski.com/test/8026/
```
LTC
```
Elo   | 0.28 +- 1.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.45 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 28306 W: 6834 L: 6811 D: 14661
Penta | [11, 3206, 7702, 3217, 17]
https://chess.aronpetkovski.com/test/8031/
```