### PR TITLE
Fail medium in stand pat

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -312,6 +312,8 @@ Eval Thread::qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta) {
 
     // Stand pat
     if (bestValue >= beta) {
+        if (std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY)
+            bestValue = (bestValue + beta) / 2;
         ttEntry->update(board->stack->hash, MOVE_NONE, ttEntry->depth, unadjustedEval, EVAL_NONE, ttPv, TT_NOBOUND);
         return bestValue;
     }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.13";
+constexpr auto VERSION = "4.0.14";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.09 +- 1.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 45534 W: 11120 L: 10846 D: 23568
Penta | [115, 5262, 11758, 5498, 134]
https://chess.aronpetkovski.com/test/8263/
```

LTC
```
Elo   | 1.10 +- 1.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.82 (-2.25, 2.89) [0.00, 3.00]
Games | N: 93286 W: 22798 L: 22503 D: 47985
Penta | [47, 10418, 25434, 10681, 63]
https://chess.aronpetkovski.com/test/8266/
```


Bench: 2459953