### PR TITLE
Interpolate between fail hard and fail soft based on depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -985,6 +985,9 @@ movesLoop:
 
     }
 
+    if (!pvNode && bestValue >= beta && std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY && std::abs(alpha) < EVAL_TBWIN_IN_MAX_PLY)
+        bestValue = (bestValue * depth + beta) / (depth + 1);
+
     if (moveCount == 0 && !stopped && !exiting) {
         if (board->stack->checkers && excluded)
             return -EVAL_INFINITE;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "4.0.14";
+constexpr auto VERSION = "4.0.15";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 5.88 +- 3.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11874 W: 2938 L: 2737 D: 6199
Penta | [34, 1326, 3023, 1513, 41]
<https://chess.aronpetkovski.com/test/8353/>
```

LTC
```
Elo   | 2.71 +- 2.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.52 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24326 W: 5952 L: 5762 D: 12612
Penta | [9, 2646, 6670, 2822, 16]
<https://chess.aronpetkovski.com/test/8355/>
```


Bench: 1984259