### PR TITLE
Decrease LMR reduction if move doesn't worsen opponents position

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -292,6 +292,7 @@ Eval Thread::qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta) {
     Eval bestValue, futilityValue, unadjustedEval;
 
     Eval correctionValue = history.getCorrectionValue(board, stack);
+    stack->correctionValue = correctionValue;
     if (board->stack->checkers) {
         stack->staticEval = bestValue = unadjustedEval = futilityValue = -EVAL_INFINITE;
         goto movesLoopQsearch;
@@ -539,6 +540,7 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     Eval eval = EVAL_NONE, unadjustedEval = EVAL_NONE, probCutBeta = EVAL_NONE;
 
     Eval correctionValue = history.getCorrectionValue(board, stack);
+    stack->correctionValue = correctionValue;
     if (board->stack->checkers) {
         stack->staticEval = EVAL_NONE;
         goto movesLoop;
@@ -559,6 +561,9 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
         ttEntry->update(board->stack->hash, MOVE_NONE, 0, unadjustedEval, EVAL_NONE, ttPv, TT_NOBOUND);
     }
+
+    if (!excluded && (stack - 1)->reduction >= 2)
+        depth += std::max(0, std::abs(correctionValue / lmrCorrection) - std::abs((stack - 1)->correctionValue / lmrCorrection)) / 1000;
 
     // IIR
     if ((!ttHit || ttDepth + 4 < depth) && depth >= iirMinDepth)
@@ -858,8 +863,11 @@ movesLoop:
             else
                 reduction -= 1000 * moveHistory / lmrHistoryFactorQuiet;
 
-            int reducedDepth = std::clamp(newDepth - reduction / 1000, 1, newDepth + pvNode);
+            reduction /= 1000;
+            int reducedDepth = std::clamp(newDepth - reduction, 1, newDepth + pvNode);
+            stack->reduction = reduction;
             value = -search<NON_PV_NODE>(board, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
+            stack->reduction = 0;
 
             if (capture && captureMoveCount < 32)
                 captureSearchCount[captureMoveCount]++;
@@ -1130,6 +1138,8 @@ void Thread::iterativeDeepening() {
                 stackList[i].move = MOVE_NONE;
                 stackList[i].capture = false;
                 stackList[i].inCheck = false;
+                stackList[i].correctionValue = 0;
+                stackList[i].reduction = 0;
             }
 
             searchData.rootDepth = depth;
@@ -1356,6 +1366,8 @@ void Thread::tdatagen() {
             stackList[i].move = MOVE_NONE;
             stackList[i].capture = false;
             stackList[i].inCheck = false;
+            stackList[i].correctionValue = 0;
+            stackList[i].reduction = 0;
         }
 
         searchData.rootDepth = depth;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -562,9 +562,6 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
         ttEntry->update(board->stack->hash, MOVE_NONE, 0, unadjustedEval, EVAL_NONE, ttPv, TT_NOBOUND);
     }
 
-    if (!excluded && (stack - 1)->reduction >= 2)
-        depth += std::max(0, std::abs(correctionValue / lmrCorrection) - std::abs((stack - 1)->correctionValue / lmrCorrection)) / 1000;
-
     // IIR
     if ((!ttHit || ttDepth + 4 < depth) && depth >= iirMinDepth)
         depth--;
@@ -576,6 +573,9 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     else if ((stack - 4)->staticEval != EVAL_NONE) {
         improving = stack->staticEval > (stack - 4)->staticEval;
     }
+
+    if ((stack - 1)->reduction >= 3 && stack->staticEval <= -(stack - 1)->staticEval)
+        depth++;
 
     // Adjust quiet history based on how much the previous move changed static eval
     if (!excluded && (stack - 1)->movedPiece != Piece::NONE && !(stack - 1)->capture && !(stack - 1)->inCheck && stack->ply > 1) {

--- a/src/types.h
+++ b/src/types.h
@@ -95,6 +95,8 @@ struct SearchStack {
     Move move;
     Piece movedPiece;
     bool inCheck, capture;
+    int correctionValue;
+    int reduction;
 
     Move excludedMove;
     Move killer;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.0";
+constexpr auto VERSION = "5.0.1";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.38 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 40596 W: 9857 L: 9579 D: 21160
Penta | [109, 4647, 10503, 4935, 104]
https://chess.aronpetkovski.com/test/8666/
```
LTC
```
Elo   | 1.46 +- 1.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.87 (-2.25, 2.89) [0.00, 2.50]
Games | N: 50832 W: 12414 L: 12201 D: 26217
Penta | [32, 5641, 13860, 5848, 35]
https://chess.aronpetkovski.com/test/8668/
```

Bench: 2031448