### PR TITLE
Increase high-ttvalue negative extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -810,7 +810,7 @@ movesLoop:
             }
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth
             else if (ttValue >= beta)
-                extension = -2 + pvNode;
+                extension = -3;
             // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low, so reduce
             else if (cutNode)
                 extension = -2;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.3";
+constexpr auto VERSION = "5.0.4";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.81 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 61190 W: 15012 L: 14694 D: 31484
Penta | [183, 7038, 15831, 7364, 179]
https://chess.aronpetkovski.com/test/8752/
```
LTC
```
Elo   | 4.09 +- 4.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.99 (-2.25, 2.89) [0.00, 2.50]
Games | N: 6548 W: 1576 L: 1499 D: 3473
Penta | [1, 703, 1791, 776, 3]
https://chess.aronpetkovski.com/test/8757/
```

Bench: 2048352