### PR TITLE
Skip LMR re-search in cases where it's unnecessary due to child node extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -585,8 +585,10 @@ Eval Thread::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
     // Post-LMR depth adjustments
     if ((stack - 1)->inLMR) {
-        if ((stack - 1)->reduction >= 3000 && stack->staticEval <= -(stack - 1)->staticEval)
+        if ((stack - 1)->reduction >= 3000 && stack->staticEval <= -(stack - 1)->staticEval) {
             depth++;
+            (stack - 1)->reduction -= 1000;
+        }
     }
 
     // Reverse futility pruning
@@ -876,6 +878,7 @@ movesLoop:
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(board, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
             stack->inLMR = false;
+            reducedDepth = std::clamp(newDepth - stack->reduction / 1000, 1, newDepth + pvNode);
             stack->reduction = 0;
 
             if (capture && captureMoveCount < 32)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.5";
+constexpr auto VERSION = "5.0.6";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 0.96 +- 1.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.45 (-2.25, 2.89) [0.00, 2.50]
Games | N: 109508 W: 26549 L: 26246 D: 56713
Penta | [313, 12785, 28227, 13144, 285]
https://chess.aronpetkovski.com/test/8916/
```

Bench: 2202685