### PR TITLE
Consider pinned pieces correctly in SEE

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -766,7 +766,7 @@ movesLoop:
                 continue;
 
             // SEE Pruning
-            if (!SEE(board, move, (2 + pvNode) * SEE_MARGIN[!capture ? lmrDepth : depth][!capture] / 2))
+            if (!SEE(board, move, (2 + (pvNode || (!capture && board->givesCheck(move)))) * SEE_MARGIN[!capture ? lmrDepth : depth][!capture] / 2))
                 continue;
 
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -766,7 +766,7 @@ movesLoop:
                 continue;
 
             // SEE Pruning
-            if (!SEE(board, move, (2 + (pvNode || (!capture && board->givesCheck(move)))) * SEE_MARGIN[!capture ? lmrDepth : depth][!capture] / 2))
+            if (!SEE(board, move, (2 + pvNode) * SEE_MARGIN[!capture ? lmrDepth : depth][!capture] / 2))
                 continue;
 
         }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.11";
+constexpr auto VERSION = "5.0.12";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 3.41 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 25672 W: 6373 L: 6121 D: 13178
Penta | [49, 2979, 6557, 3173, 78]
```
https://furybench.com/test/42/

Bench: 1876114