### PR TITLE
Correctly classify quiet ttmoves in probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -664,7 +664,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
             Square origin = moveOrigin(move);
             Square target = moveTarget(move);
-            stack->capture = true;
+            stack->capture = board->isCapture(move);
             stack->move = move;
             stack->movedPiece = board->pieces[origin];
             stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.15";
+constexpr auto VERSION = "5.0.16";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 2.52 +- 2.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 14498 W: 3538 L: 3433 D: 7527
Penta | [26, 1650, 3808, 1723, 42]
https://furybench.com/test/340/
```

Bench: 2021781