### PR TITLE
Revert "Fix upcoming repetition detection (#349)"

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1180,28 +1180,29 @@ bool Board::hasUpcomingRepetition(int ply) {
     if (maxPlyOffset < 3)
         return false;
 
+    uint64_t hash = stack->hash;
     BoardStack* compareStack = stack->previous;
-    uint64_t delta = stack->hash ^ compareStack->hash ^ ZOBRIST_STM_BLACK;
 
     int j = 0;
     for (int i = 3; i <= maxPlyOffset; i += 2) {
-        delta ^= compareStack->previous->hash ^ compareStack->previous->previous->hash ^ ZOBRIST_STM_BLACK;
         compareStack = compareStack->previous->previous;
 
-        if (delta)
-            continue;
-
-        uint64_t moveHash = stack->hash ^ compareStack->hash;
+        uint64_t moveHash = hash ^ compareStack->hash;
         if ((j = H1(moveHash), CUCKOO_HASHES[j] == moveHash) || (j = H2(moveHash), CUCKOO_HASHES[j] == moveHash)) {
             Move move = CUCKOO_MOVES[j];
             Square origin = moveOrigin(move);
             Square target = moveTarget(move);
 
-            if ((BB::BETWEEN[origin][target] ^ bitboard(target)) & (byColor[Color::WHITE] | byColor[Color::BLACK]))
+            if (BB::BETWEEN[origin][target] & (byColor[Color::WHITE] | byColor[Color::BLACK]))
                 continue;
 
-            if (ply >= i)
+            if (ply > i)
                 return true;
+
+            Square pieceSquare = pieces[origin] == Piece::NONE ? target : origin;
+            Color pieceColor = (byColor[Color::WHITE] & bitboard(pieceSquare)) ? Color::WHITE : Color::BLACK;
+            if (pieceColor != stm)
+                continue;
 
             // Check for 2-fold repetition
             BoardStack* compareStack2 = compareStack;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.19";
+constexpr auto VERSION = "5.0.20";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
This reverts commit c9d168c6d6ffa877a1e6bc56292737375c97a0dd, since it failed LTC simplification

```
Elo   | -3.65 +- 3.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.25 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 10178 W: 2404 L: 2511 D: 5263
Penta | [2, 1198, 2796, 1091, 2]
https://furybench.com/test/447/
```

Bench: 1912487