### PR TITLE
Limit LMR depth for HP and SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,6 @@ movesLoop:
             ) {
 
             int lmrDepth = std::max(0, depth - earlyLmrReductionTableFactor * REDUCTIONS[!capture][depth][moveCount] / 1000000 - !improving + moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
-            lmrDepth = std::min(depth + 1, lmrDepth);
 
             if (!pvNode && !movegen.skipQuiets) {
 
@@ -755,6 +754,8 @@ movesLoop:
                 if (lmrDepth < fpCaptDepth && eval + fpCaptBase + PIECE_VALUES[capturedPiece] + fpCaptFactor * lmrDepth <= alpha)
                     continue;
             }
+
+            lmrDepth = std::min(std::min(depth + 1, MAX_PLY - 1), lmrDepth);
 
             // History pruning
             int hpFactor = capture ? historyPruningFactorCapture : historyPruningFactorQuiet;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -734,7 +734,7 @@ movesLoop:
             ) {
 
             int lmrDepth = std::max(0, depth - earlyLmrReductionTableFactor * REDUCTIONS[!capture][depth][moveCount] / 1000000 - !improving + moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
-            lmrDepth = std::min(MAX_PLY - 1, lmrDepth);
+            lmrDepth = std::min(depth + 1, lmrDepth);
 
             if (!pvNode && !movegen.skipQuiets) {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.23";
+constexpr auto VERSION = "5.0.24";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.23 +- 1.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 115252 W: 27944 L: 27536 D: 59772
Penta | [204, 13290, 30254, 13650, 228]
https://furybench.com/test/733/
```
LTC
```
Elo   | 1.69 +- 1.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.50 (-2.25, 2.89) [0.00, 2.50]
Games | N: 31710 W: 7857 L: 7703 D: 16150
Penta | [16, 3465, 8736, 3625, 13]
https://furybench.com/test/741/
```

Bench: 2082559