### PR TITLE
TT Secondary Aging

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -14,6 +14,8 @@ void TTEntry::update(uint64_t _hash, Move _bestMove, uint8_t _depth, Eval _eval,
         eval = _eval;
         flags = (uint8_t)(_flags + (wasPv << 2)) | TT_GENERATION_COUNTER;
     }
+    else if (depth >= 5 && flags != TT_EXACTBOUND)
+        depth--;
 }
 
 TTEntry* TranspositionTable::probe(uint64_t hash, bool* found) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "5.0.25";
+constexpr auto VERSION = "5.0.26";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.07 +- 0.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 160292 W: 39131 L: 38639 D: 82522
Penta | [332, 18630, 41767, 19048, 369]
```
https://furybench.com/test/914/

```
Elo   | 1.19 +- 0.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 112460 W: 27668 L: 27283 D: 57509
Penta | [42, 12404, 30961, 12773, 50]
```
https://furybench.com/test/918/

bench 2019136