### PR TITLE
Remove recapture and check conditions in qsearch LMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -343,7 +343,7 @@ movesLoopQsearch:
             if (!SEE(board, move, qsSeeMargin))
                 break;
 
-            if (moveTarget(move) != moveTarget((stack - 1)->move) && (moveType(move) != MOVE_PROMOTION) && !board->givesCheck(move) && moveCount > 2)
+            if ((moveType(move) != MOVE_PROMOTION) && moveCount > 2)
                 continue;
         }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.0";
+constexpr auto VERSION = "6.0.1";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.45 +- 1.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 85660 W: 20977 L: 20619 D: 44064
Penta | [198, 9877, 22322, 10235, 198]
https://furybench.com/test/1078/
```
LTC
```
Elo   | 1.62 +- 1.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.19 (-2.25, 2.89) [0.00, 2.50]
Games | N: 49058 W: 11991 L: 11762 D: 25305
Penta | [23, 5343, 13570, 5568, 25]
https://furybench.com/test/1081/
```

Bench: 2104657