### PR TITLE
Improve binary performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+CC  = clang
+CFLAGS = -mpopcnt -Wall -pedantic -Wextra -fcommon -pthread -O3 -flto=auto -fuse-ld=lld
 CXX = clang++
-CXXFLAGS = -std=c++17 -Wall -pedantic -Wextra -fcommon -pthread -O3
+CXXFLAGS = -std=c++17 -Wall -pedantic -Wextra -fcommon -pthread -O3 -flto=auto -fuse-ld=lld
 CXXFLAGS_EXTRA = 
 
 SOURCES = src/engine.cpp src/board.cpp src/move.cpp src/uci.cpp src/search.cpp src/thread.cpp src/evaluation.cpp src/tt.cpp src/magic.cpp src/bitboard.cpp src/history.cpp src/nnue.cpp src/time.cpp src/spsa.cpp src/zobrist.cpp src/datagen.cpp src/fathom/src/tbprobe.c
@@ -55,14 +57,19 @@ ifeq ($(arch), arm64)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_ARM
 else ifeq ($(arch), avx512vnni)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86 -march=cascadelake
+	CFLAGS := $(CFLAGS) -march=cascadelake
 else ifeq ($(arch), avx512)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86 -march=skylake-avx512
+	CFLAGS := $(CFLAGS) -march=skylake-avx512
 else ifeq ($(arch), avx2)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86 -march=haswell
+	CFLAGS := $(CFLAGS) -march=haswell
 else ifeq ($(arch), fma)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86 -mssse3 -mfma
+	CFLAGS := $(CFLAGS) -mssse3 -mfma
 else ifeq ($(arch), ssse3)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86 -mssse3
+	CFLAGS := $(CFLAGS) -mssse3
 else ifeq ($(arch), generic)
 	CXXFLAGS := $(CXXFLAGS) -DARCH_X86
 else ifneq ($(origin arch), undefined)
@@ -84,6 +91,7 @@ $(error Architecture not supported: $(ARCH_CMD))
 	endif
 
 	CXXFLAGS := $(CXXFLAGS) -march=native
+	CFLAGS := $(CFLAGS) -march=native
 	ifeq ($(OS), Windows_NT)
 		HAS_BMI2 := $(shell .\detect_flags.bat $(CXX) __BMI2__)
 		IS_ZEN1  := $(shell .\detect_flags.bat $(CXX) __znver1)
@@ -105,6 +113,7 @@ endif
 
 ifdef BMI2
 	CXXFLAGS := $(CXXFLAGS) -DUSE_BMI2 -mbmi2
+	CFLAGS := $(CFLAGS) -mbmi2
 endif
 
 ifdef PROCESS_NET
@@ -116,7 +125,7 @@ endif
 
 # Windows only flags
 ifeq ($(OS), Windows_NT)
-	CXXFLAGS := $(CXXFLAGS) -lstdc++ -static -Wl,--no-as-needed
+	CXXFLAGS := $(CXXFLAGS) -lstdc++ -static
 endif
 
 # Network flags
@@ -176,4 +185,4 @@ _nopgo:	$(OBJS)
 		$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(filter-out $(EVALFILE) process-net,$^) -o $(PROGRAM)
 
 clean:	
-		$(RM) src/*.o *~ engine processed.bin
+		$(RM) src/*.o src/fathom/src/*.o *~ engine processed.bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CC  = clang
-CFLAGS = -mpopcnt -Wall -pedantic -Wextra -fcommon -pthread -O3 -flto=auto -fuse-ld=lld
 CXX = clang++
-CXXFLAGS = -std=c++17 -Wall -pedantic -Wextra -fcommon -pthread -O3 -flto=auto -fuse-ld=lld
+CFLAGS = -mpopcnt -w -pthread -O3 -flto=auto
+CXXFLAGS = -std=c++17 -Wall -pedantic -Wextra -fcommon -pthread -O3 -flto=auto
+LDFLAGS = 
 CXXFLAGS_EXTRA = 
 
 SOURCES = src/engine.cpp src/board.cpp src/move.cpp src/uci.cpp src/search.cpp src/thread.cpp src/evaluation.cpp src/tt.cpp src/magic.cpp src/bitboard.cpp src/history.cpp src/nnue.cpp src/time.cpp src/spsa.cpp src/zobrist.cpp src/datagen.cpp src/fathom/src/tbprobe.c
@@ -125,7 +126,13 @@ endif
 
 # Windows only flags
 ifeq ($(OS), Windows_NT)
-	CXXFLAGS := $(CXXFLAGS) -lstdc++ -static
+	CXXFLAGS := $(CXXFLAGS) -static
+	LDFLAGS := $(LDFLAGS) -lstdc++
+endif
+# Non-MacOS flags
+UNAME_S := $(shell uname -s)
+ifneq ($(UNAME_S), Darwin)
+	LDFLAGS := $(LDFLAGS) -fuse-ld=lld
 endif
 
 # Network flags
@@ -174,7 +181,7 @@ endif
 
 _pgo:	CXXFLAGS_EXTRA := $(PGO_GENERATE)
 _pgo:	$(OBJS)
-		$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(filter-out $(EVALFILE) process-net,$^) -o $(PROGRAM)
+		$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(LDFLAGS) $(filter-out $(EVALFILE) process-net,$^) -o $(PROGRAM)
 		./$(PROGRAM) bench
 		$(RM) src/*.o *~ engine
 		$(PGO_MERGE)
@@ -182,7 +189,7 @@ _pgo:	$(OBJS)
 		$(RM) -rf $(PGO_FILES)
 
 _nopgo:	$(OBJS)
-		$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(filter-out $(EVALFILE) process-net,$^) -o $(PROGRAM)
+		$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(LDFLAGS) $(filter-out $(EVALFILE) process-net,$^) -o $(PROGRAM)
 
 clean:	
 		$(RM) src/*.o src/fathom/src/*.o *~ engine processed.bin

--- a/create_release.ps1
+++ b/create_release.ps1
@@ -1,7 +1,7 @@
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-generic.exe arch=generic -j
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-ssse3.exe arch=ssse3 -j
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-fma.exe arch=fma -j
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-avx2.exe arch=avx2 -j profile-build
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-bmi2.exe arch=avx2 BMI2=true -j profile-build
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-avx512.exe arch=avx512 BMI2=true -j profile-build
-make clean && make CXX=g++ EXE=PlentyChess-$args-windows-avx512vnni.exe arch=avx512vnni BMI2=true -j profile-build
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-generic.exe arch=generic -j
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-ssse3.exe arch=ssse3 -j
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-fma.exe arch=fma -j
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-avx2.exe arch=avx2 -j profile-build
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-bmi2.exe arch=avx2 BMI2=true -j profile-build
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-avx512.exe arch=avx512 BMI2=true -j profile-build
+make clean && make profile-build CXX=g++ EXE=PlentyChess-$args-windows-avx512vnni.exe arch=avx512vnni BMI2=true -j profile-build

--- a/src/incbin/incbin.h
+++ b/src/incbin/incbin.h
@@ -1,4 +1,3 @@
-#pragma once
 /**
  * @file incbin.h
  * @author Dale Weiler
@@ -10,20 +9,31 @@
 #ifndef INCBIN_HDR
 #define INCBIN_HDR
 #include <limits.h>
-#if defined(__AVX512BW__) || defined(__AVX512CD__) || defined(__AVX512DQ__) || \
-    defined(__AVX512ER__) || defined(__AVX512PF__) || defined(__AVX512VL__) || \
-    defined(__AVX512F__)
-#define INCBIN_ALIGNMENT_INDEX 6
-#elif defined(__AVX__) || defined(__AVX2__)
-#define INCBIN_ALIGNMENT_INDEX 5
-#elif defined(__SSE__) || defined(__SSE2__) || defined(__SSE3__) ||            \
-    defined(__SSSE3__) || defined(__SSE4_1__) || defined(__SSE4_2__) ||        \
-    defined(__neon__)
-#define INCBIN_ALIGNMENT_INDEX 4
+#if   defined(__AVX512BW__) || \
+      defined(__AVX512CD__) || \
+      defined(__AVX512DQ__) || \
+      defined(__AVX512ER__) || \
+      defined(__AVX512PF__) || \
+      defined(__AVX512VL__) || \
+      defined(__AVX512F__)
+# define INCBIN_ALIGNMENT_INDEX 6
+#elif defined(__AVX__)      || \
+      defined(__AVX2__)
+# define INCBIN_ALIGNMENT_INDEX 5
+#elif defined(__SSE__)      || \
+      defined(__SSE2__)     || \
+      defined(__SSE3__)     || \
+      defined(__SSSE3__)    || \
+      defined(__SSE4_1__)   || \
+      defined(__SSE4_2__)   || \
+      defined(__neon__)     || \
+      defined(__ARM_NEON)   || \
+      defined(__ALTIVEC__)
+# define INCBIN_ALIGNMENT_INDEX 4
 #elif ULONG_MAX != 0xffffffffu
-#define INCBIN_ALIGNMENT_INDEX 3
-#else
-#define INCBIN_ALIGNMENT_INDEX 2
+# define INCBIN_ALIGNMENT_INDEX 3
+# else
+# define INCBIN_ALIGNMENT_INDEX 2
 #endif
 
 /* Lookup table of (1 << n) where `n' is `INCBIN_ALIGNMENT_INDEX' */
@@ -36,129 +46,159 @@
 #define INCBIN_ALIGN_SHIFT_6 64
 
 /* Actual alignment value */
-#define INCBIN_ALIGNMENT                                                       \
-  INCBIN_CONCATENATE(INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _),                \
-                     INCBIN_ALIGNMENT_INDEX)
+#define INCBIN_ALIGNMENT \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+        INCBIN_ALIGNMENT_INDEX)
 
 /* Stringize */
-#define INCBIN_STR(X) #X
-#define INCBIN_STRINGIZE(X) INCBIN_STR(X)
+#define INCBIN_STR(X) \
+    #X
+#define INCBIN_STRINGIZE(X) \
+    INCBIN_STR(X)
 /* Concatenate */
-#define INCBIN_CAT(X, Y) X##Y
-#define INCBIN_CONCATENATE(X, Y) INCBIN_CAT(X, Y)
+#define INCBIN_CAT(X, Y) \
+    X ## Y
+#define INCBIN_CONCATENATE(X, Y) \
+    INCBIN_CAT(X, Y)
 /* Deferred macro expansion */
-#define INCBIN_EVAL(X) X
-#define INCBIN_INVOKE(N, ...) INCBIN_EVAL(N(__VA_ARGS__))
+#define INCBIN_EVAL(X) \
+    X
+#define INCBIN_INVOKE(N, ...) \
+    INCBIN_EVAL(N(__VA_ARGS__))
+/* Variable argument count for overloading by arity */
+#define INCBIN_VA_ARG_COUNTER(_1, _2, _3, N, ...) N
+#define INCBIN_VA_ARGC(...) INCBIN_VA_ARG_COUNTER(__VA_ARGS__, 3, 2, 1, 0)
 
 /* Green Hills uses a different directive for including binary data */
 #if defined(__ghs__)
-#if (__ghs_asm == 2)
-#define INCBIN_MACRO ".file"
+#  if (__ghs_asm == 2)
+#    define INCBIN_MACRO ".file"
 /* Or consider the ".myrawdata" entry in the ld file */
+#  else
+#    define INCBIN_MACRO "\tINCBIN"
+#  endif
 #else
-#define INCBIN_MACRO "\tINCBIN"
-#endif
-#else
-#define INCBIN_MACRO ".incbin"
+#  define INCBIN_MACRO ".incbin"
 #endif
 
 #ifndef _MSC_VER
-#define INCBIN_ALIGN __attribute__((aligned(INCBIN_ALIGNMENT)))
+#  define INCBIN_ALIGN \
+    __attribute__((aligned(INCBIN_ALIGNMENT)))
 #else
-#define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
+#  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
 #endif
 
-#if defined(__arm__) || /* GNU C and RealView */                               \
-    defined(__arm) ||   /* Diab */                                             \
-    defined(_ARM)       /* ImageCraft */
-#define INCBIN_ARM
+#if defined(__arm__) || /* GNU C and RealView */ \
+    defined(__arm) || /* Diab */ \
+    defined(_ARM) /* ImageCraft */
+#  define INCBIN_ARM
 #endif
 
 #ifdef __GNUC__
 /* Utilize .balign where supported */
-#define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
-#define INCBIN_ALIGN_BYTE ".balign 1\n"
+#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".balign 1\n"
 #elif defined(INCBIN_ARM)
 /*
  * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
  * the shift count. This is the value passed to `.align'
  */
-#define INCBIN_ALIGN_HOST                                                      \
-  ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
-#define INCBIN_ALIGN_BYTE ".align 0\n"
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 0\n"
 #else
 /* We assume other inline assembler's treat `.align' as `.balign' */
-#define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
-#define INCBIN_ALIGN_BYTE ".align 1\n"
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 1\n"
 #endif
 
 /* INCBIN_CONST is used by incbin.c generated files */
 #if defined(__cplusplus)
-#define INCBIN_EXTERNAL extern "C"
-#define INCBIN_CONST extern const
+#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_CONST    extern const
 #else
-#define INCBIN_EXTERNAL extern
-#define INCBIN_CONST const
+#  define INCBIN_EXTERNAL extern
+#  define INCBIN_CONST    const
+#endif
+
+/**
+ * @brief Optionally override the linker section into which size and data is
+ * emitted.
+ * 
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION ".rodata"
+#  endif
 #endif
 
 /**
  * @brief Optionally override the linker section into which data is emitted.
  *
- * @warning If you use this facility, you'll have to deal with platform-specific
- * linker output section naming on your own
- *
- * Overriding the default linker output section, e.g for esp8266/Arduino:
- * @code
- * #define INCBIN_OUTPUT_SECTION ".irom.text"
- * #include "incbin.h"
- * INCBIN(Foo, "foo.txt");
- * // Data is emitted into program memory that never gets copied to RAM
- * @endcode
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
  */
-#if !defined(INCBIN_OUTPUT_SECTION)
-#if defined(__APPLE__)
-#define INCBIN_OUTPUT_SECTION ".const_data"
-#else
-#define INCBIN_OUTPUT_SECTION ".rodata"
+#if !defined(INCBIN_OUTPUT_DATA_SECTION)
+#  define INCBIN_OUTPUT_DATA_SECTION INCBIN_OUTPUT_SECTION
 #endif
+
+/**
+ * @brief Optionally override the linker section into which size is emitted.
+ *
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ * 
+ * @note This is useful for Harvard architectures where program memory cannot
+ * be directly read from the program without special instructions. With this you
+ * can chose to put the size variable in RAM rather than ROM.
+ */
+#if !defined(INCBIN_OUTPUT_SIZE_SECTION)
+#  define INCBIN_OUTPUT_SIZE_SECTION INCBIN_OUTPUT_SECTION
 #endif
 
 #if defined(__APPLE__)
+#  include "TargetConditionals.h"
+#  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
+#    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."
+#  endif
 /* The directives are different for Apple branded compilers */
-#define INCBIN_SECTION INCBIN_OUTPUT_SECTION "\n"
-#define INCBIN_GLOBAL(NAME)                                                    \
-  ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
-#define INCBIN_INT ".long "
-#define INCBIN_MANGLE "_"
-#define INCBIN_BYTE ".byte "
-#define INCBIN_TYPE(...)
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_INT             ".long "
+#  define INCBIN_MANGLE          "_"
+#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_TYPE(...)
 #else
-#define INCBIN_SECTION ".section " INCBIN_OUTPUT_SECTION "\n"
-#define INCBIN_GLOBAL(NAME)                                                    \
-  ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
-#if defined(__ghs__)
-#define INCBIN_INT ".word "
-#else
-#define INCBIN_INT ".int "
-#endif
-#if defined(__USER_LABEL_PREFIX__)
-#define INCBIN_MANGLE INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
-#else
-#define INCBIN_MANGLE ""
-#endif
-#if defined(INCBIN_ARM)
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  if defined(__ghs__)
+#    define INCBIN_INT           ".word "
+#  else
+#    define INCBIN_INT           ".int "
+#  endif
+#  if defined(__USER_LABEL_PREFIX__)
+#    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
+#  else
+#    define INCBIN_MANGLE        ""
+#  endif
+#  if defined(INCBIN_ARM)
 /* On arm assemblers, `@' is used as a line comment token */
-#define INCBIN_TYPE(NAME)                                                      \
-  ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
-#elif defined(__MINGW32__) || defined(__MINGW64__)
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#  elif defined(__MINGW32__) || defined(__MINGW64__)
 /* Mingw doesn't support this directive either */
-#define INCBIN_TYPE(NAME)
-#else
+#    define INCBIN_TYPE(NAME)
+#  elif defined(_WIN32)
+// CIEKCE: this just doesn't work on windows at all
+#    define INCBIN_TYPE(NAME)
+#  else
 /* It's safe to use `@' on other architectures */
-#define INCBIN_TYPE(NAME)                                                      \
-  ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
-#endif
-#define INCBIN_BYTE ".byte "
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#  endif
+#  define INCBIN_BYTE            ".byte "
 #endif
 
 /* List of style types used for symbol names */
@@ -168,31 +208,21 @@
 /**
  * @brief Specify the prefix to use for symbol names.
  *
- * By default this is `g', producing symbols of the form:
- * @code
- * #include "incbin.h"
- * INCBIN(Foo, "foo.txt");
+ * @note By default this is "g".
  *
- * // Now you have the following symbols:
- * // const unsigned char gFooData[];
- * // const unsigned char *const gFooEnd;
- * // const unsigned int gFooSize;
- * @endcode
- *
- * If however you specify a prefix before including: e.g:
  * @code
  * #define INCBIN_PREFIX incbin
  * #include "incbin.h"
  * INCBIN(Foo, "foo.txt");
  *
  * // Now you have the following symbols instead:
- * // const unsigned char incbinFooData[];
- * // const unsigned char *const incbinFooEnd;
- * // const unsigned int incbinFooSize;
+ * // const unsigned char incbinFoo<data>[];
+ * // const unsigned char *const incbinFoo<end>;
+ * // const unsigned int incbinFoo<size>;
  * @endcode
  */
 #if !defined(INCBIN_PREFIX)
-#define INCBIN_PREFIX g
+#  define INCBIN_PREFIX g
 #endif
 
 /**
@@ -202,18 +232,8 @@
  * - INCBIN_STYLE_CAMEL "CamelCase"
  * - INCBIN_STYLE_SNAKE "snake_case"
  *
- * Default option is *INCBIN_STYLE_CAMEL* producing symbols of the form:
- * @code
- * #include "incbin.h"
- * INCBIN(Foo, "foo.txt");
+ * @note By default this is INCBIN_STYLE_CAMEL
  *
- * // Now you have the following symbols:
- * // const unsigned char <prefix>FooData[];
- * // const unsigned char *const <prefix>FooEnd;
- * // const unsigned int <prefix>FooSize;
- * @endcode
- *
- * If however you specify a style before including: e.g:
  * @code
  * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
  * #include "incbin.h"
@@ -226,7 +246,7 @@
  * @endcode
  */
 #if !defined(INCBIN_STYLE)
-#define INCBIN_STYLE INCBIN_STYLE_CAMEL
+#  define INCBIN_STYLE INCBIN_STYLE_CAMEL
 #endif
 
 /* Style lookup tables */
@@ -238,23 +258,35 @@
 #define INCBIN_STYLE_1_SIZE _size
 
 /* Style lookup: returning identifier */
-#define INCBIN_STYLE_IDENT(TYPE)                                               \
-  INCBIN_CONCATENATE(INCBIN_STYLE_,                                            \
-                     INCBIN_CONCATENATE(INCBIN_EVAL(INCBIN_STYLE),             \
-                                        INCBIN_CONCATENATE(_, TYPE)))
+#define INCBIN_STYLE_IDENT(TYPE) \
+    INCBIN_CONCATENATE( \
+        INCBIN_STYLE_, \
+        INCBIN_CONCATENATE( \
+            INCBIN_EVAL(INCBIN_STYLE), \
+            INCBIN_CONCATENATE(_, TYPE)))
 
 /* Style lookup: returning string literal */
-#define INCBIN_STYLE_STRING(TYPE) INCBIN_STRINGIZE(INCBIN_STYLE_IDENT(TYPE))
+#define INCBIN_STYLE_STRING(TYPE) \
+    INCBIN_STRINGIZE( \
+        INCBIN_STYLE_IDENT(TYPE)) \
 
 /* Generate the global labels by indirectly invoking the macro with our style
  * type and concatenating the name against them. */
-#define INCBIN_GLOBAL_LABELS(NAME, TYPE)                                       \
-  INCBIN_INVOKE(                                                               \
-      INCBIN_GLOBAL,                                                           \
-      INCBIN_CONCATENATE(NAME, INCBIN_INVOKE(INCBIN_STYLE_IDENT, TYPE)))       \
-  INCBIN_INVOKE(                                                               \
-      INCBIN_TYPE,                                                             \
-      INCBIN_CONCATENATE(NAME, INCBIN_INVOKE(INCBIN_STYLE_IDENT, TYPE)))
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
+    INCBIN_INVOKE( \
+        INCBIN_GLOBAL, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE))) \
+    INCBIN_INVOKE( \
+        INCBIN_TYPE, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE)))
 
 /**
  * @brief Externally reference binary data included in another translation unit.
@@ -265,34 +297,79 @@
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
  * "Data", as well as "End" and "Size" after. An example is provided below.
  *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
  * @param NAME The name given for the binary data
  *
  * @code
  * INCBIN_EXTERN(Foo);
  *
  * // Now you have the following symbols:
- * // extern const unsigned char <prefix>FooData[];
- * // extern const unsigned char *const <prefix>FooEnd;
- * // extern const unsigned int <prefix>FooSize;
+ * // extern const unsigned char <prefix>Foo<data>[];
+ * // extern const unsigned char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * @code
+ * INCBIN_EXTERN(custom_type, Foo);
+ * 
+ * // Now you have the following symbols:
+ * // extern const custom_type <prefix>Foo<data>[];
+ * // extern const custom_type *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
  * @endcode
  */
-#define INCBIN_EXTERN(NAME)                                                    \
-  INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char INCBIN_CONCATENATE(         \
-      INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), INCBIN_STYLE_IDENT(DATA))[];    \
-  INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char *const INCBIN_CONCATENATE(  \
-      INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), INCBIN_STYLE_IDENT(END));       \
-  INCBIN_EXTERNAL const unsigned int INCBIN_CONCATENATE(                       \
-      INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), INCBIN_STYLE_IDENT(SIZE))
+#define INCBIN_EXTERN(...) \
+    INCBIN_CONCATENATE(INCBIN_EXTERN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#define INCBIN_EXTERN_1(NAME, ...) \
+    INCBIN_EXTERN_2(unsigned char, NAME)
+#define INCBIN_EXTERN_2(TYPE, NAME) \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(DATA))[]; \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE *const \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+        INCBIN_STYLE_IDENT(END)); \
+    INCBIN_EXTERNAL const unsigned int \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(SIZE))
 
 /**
- * @brief Include a binary file into the current translation unit.
+ * @brief Externally reference textual data included in another translation unit.
  *
- * Includes a binary file into the current translation unit, producing three
- * symbols for objects that encode the data and size respectively.
+ * Produces three external symbols that reference the textual data included in
+ * another translation unit.
  *
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
  * "Data", as well as "End" and "Size" after. An example is provided below.
  *
+ * @param NAME The name given for the textual data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const char <prefix>Foo<data>[];
+ * // extern const char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ */
+#define INCTXT_EXTERN(NAME) \
+    INCBIN_EXTERN_2(char, NAME)
+
+/**
+ * @brief Include a binary file into the current translation unit.
+ *
+ * Includes a binary file into the current translation unit, producing three symbols
+ * for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
  * @param NAME The name to associate with this binary data (as an identifier.)
  * @param FILENAME The file to include (as a string literal.)
  *
@@ -300,9 +377,20 @@
  * INCBIN(Icon, "icon.png");
  *
  * // Now you have the following symbols:
- * // const unsigned char <prefix>IconData[];
- * // const unsigned char *const <prefix>IconEnd;
- * // const unsigned int <prefix>IconSize;
+ * // const unsigned char <prefix>Icon<data>[];
+ * // const unsigned char *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * These macros are specialized by arity.
+ * @code
+ * INCBIN(custom_type, Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const custom_type <prefix>Icon<data>[];
+ * // const custom_type *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
  * @endcode
  *
  * @warning This must be used in global scope
@@ -312,27 +400,80 @@
  * please @see INCBIN_EXTERN.
  */
 #ifdef _MSC_VER
-#define INCBIN(NAME, FILENAME) INCBIN_EXTERN(NAME)
+#  define INCBIN(NAME, FILENAME) \
+      INCBIN_EXTERN(NAME)
 #else
-#define INCBIN(NAME, FILENAME)                                                                        \
-  __asm__(                                                                                            \
-      INCBIN_SECTION INCBIN_GLOBAL_LABELS(                                                            \
-          NAME, DATA) INCBIN_ALIGN_HOST INCBIN_MANGLE                                                 \
-          INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(                                  \
-              DATA) ":\n" INCBIN_MACRO " \"" FILENAME                                                 \
-                    "\"\n" INCBIN_GLOBAL_LABELS(                                                      \
-                        NAME, END) INCBIN_ALIGN_BYTE INCBIN_MANGLE                                    \
-                        INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(                    \
-                            END) ":\n" INCBIN_BYTE "1\n" INCBIN_GLOBAL_LABELS(NAME,                   \
-                                                                              SIZE)                   \
-                            INCBIN_ALIGN_HOST INCBIN_MANGLE INCBIN_STRINGIZE(                         \
-                                INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" INCBIN_INT       \
-                                INCBIN_MANGLE INCBIN_STRINGIZE(                                       \
-                                    INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " INCBIN_MANGLE \
-                                    INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(        \
-                                        DATA) "\n" INCBIN_ALIGN_HOST                                  \
-                                              ".text\n");                                             \
-  INCBIN_EXTERN(NAME)
-
+#  define INCBIN(...) \
+     INCBIN_CONCATENATE(INCBIN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#  if defined(__GNUC__)
+#    define INCBIN_1(...) _Pragma("GCC error \"Single argument INCBIN not allowed\"")
+#  elif defined(__clang__)
+#    define INCBIN_1(...) _Pragma("clang error \"Single argument INCBIN not allowed\"")
+#  else
+#    define INCBIN_1(...) /* Cannot do anything here */
+#  endif
+#  define INCBIN_2(NAME, FILENAME) \
+      INCBIN_3(unsigned char, NAME, FILENAME)
+#  define INCBIN_3(TYPE, NAME, FILENAME) INCBIN_COMMON(TYPE, NAME, FILENAME, /* No terminator for binary data */)
+#  define INCBIN_COMMON(TYPE, NAME, FILENAME, TERMINATOR) \
+    __asm__(INCBIN_SECTION \
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
+            INCBIN_MACRO " \"" FILENAME "\"\n" \
+                TERMINATOR \
+            INCBIN_GLOBAL_LABELS(NAME, END) \
+            INCBIN_ALIGN_BYTE \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+                INCBIN_BYTE "1\n" \
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
+            INCBIN_ALIGN_HOST \
+            ".text\n" \
+    ); \
+    INCBIN_EXTERN(TYPE, NAME)
 #endif
+
+/**
+ * @brief Include a textual file into the current translation unit.
+ * 
+ * This behaves the same as INCBIN except it produces char compatible arrays
+ * and implicitly adds a null-terminator byte, thus the size of data included
+ * by this is one byte larger than that of INCBIN.
+ *
+ * Includes a textual file into the current translation unit, producing three
+ * symbols for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCTXT(Readme, "readme.txt");
+ *
+ * // Now you have the following symbols:
+ * // const char <prefix>Readme<data>[];
+ * // const char *const <prefix>Readme<end>;
+ * // const unsigned int <prefix>Readme<size>;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#if defined(_MSC_VER)
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_EXTERN(NAME)
+#else
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_COMMON(char, NAME, FILENAME, INCBIN_BYTE "0\n")
+#endif
+
 #endif

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -6,17 +6,28 @@
 
 #include "nnue.h"
 #include "board.h"
-#include "incbin/incbin.h"
 
 #if defined(ARCH_ARM)
 #include <arm_neon.h>
 #endif
 
+#ifdef _MSC_VER
+    #define SP_MSVC
+    #pragma push_macro("_MSC_VER")
+    #undef _MSC_VER
+#endif
+
+#include "incbin/incbin.h"
 // This will define the following variables:
 // const unsigned char        gNETWORKData[];
 // const unsigned char *const gNETWORKEnd;
 // const unsigned int         gNETWORKSize;
 INCBIN(NETWORK, EVALFILE);
+
+#ifdef SP_MSVC
+    #pragma pop_macro("_MSC_VER")
+    #undef SP_MSVC
+#endif
 
 NetworkData* networkData;
 alignas(ALIGNMENT) uint16_t nnzLookup[256][8];

--- a/src/tt.h
+++ b/src/tt.h
@@ -33,6 +33,14 @@ inline void* alignedAlloc(size_t alignment, size_t requiredBytes) {
     return ptr;
 }
 
+inline void alignedFree(void* ptr) {
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+}
+
 constexpr uint8_t TT_NOBOUND = 0;
 constexpr uint8_t TT_UPPERBOUND = 1;
 constexpr uint8_t TT_LOWERBOUND = 2;
@@ -89,7 +97,7 @@ public:
     }
 
     ~TranspositionTable() {
-        std::free(table);
+        alignedFree(table);
     }
 
     void newSearch() {
@@ -102,7 +110,7 @@ public:
             return;
         
         if (table)
-            std::free(table);
+            alignedFree(table);
         
         clusterCount = newClusterCount;
         table = static_cast<TTCluster*>(alignedAlloc(sizeof(TTCluster), clusterCount * sizeof(TTCluster)));

--- a/src/tt.h
+++ b/src/tt.h
@@ -20,14 +20,10 @@
 
 inline void* alignedAlloc(size_t alignment, size_t requiredBytes) {
     void* ptr;
-#if defined(__MINGW32__)
-    int offset = alignment - 1;
-    void* p = (void*)malloc(requiredBytes + offset);
-    ptr = (void*)(((size_t)(p)+offset) & ~(alignment - 1));
-#elif defined (__GNUC__)
-    ptr = std::aligned_alloc(alignment, requiredBytes);
+#if defined(_WIN32)
+    ptr = _aligned_malloc(requiredBytes, alignment);
 #else
-#error "Compiler not supported"
+    ptr = std::aligned_alloc(alignment, requiredBytes);
 #endif
 
 #if defined(__linux__)


### PR DESCRIPTION
- Switch to clang on windows (native, not mingw)
- Compile fathom with correct optimisations
- Use flto and lld

Measured a roughly 10% speedup on windows, which was confirmed by Stefan Pohl.
Thanks to Ciekce for helping me with incbin on the new clang setup.

Bench: 2104657