### PR TITLE
Fix build on MacOs Darwin with clang compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,8 @@ else
 				LDFLAGS := $(LDFLAGS) -fuse-ld=lld
 			endif
 		endif
+	else
+	    CFLAGS := $(filter-out -mpopcnt,$(CFLAGS))
 	endif
 endif
 

--- a/src/incbin/incbin.h
+++ b/src/incbin/incbin.h
@@ -161,6 +161,7 @@
 #endif
 
 #if defined(__APPLE__)
+#define INCBIN_SILENCE_BITCODE_WARNING
 #  include "TargetConditionals.h"
 #  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
 #    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."


### PR DESCRIPTION
Remove compiler error "clang++: error: unsupported option '-mpopcnt' for target 'arm64-apple-darwin24.5.0'" and remove warning "src/incbin/incbin.h:166:6: warning: #warning is a C++23 extension [-Wpedantic]".