### PR TITLE
Require higher depth for TT beta cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -594,7 +594,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth + (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.6";
+constexpr auto VERSION = "6.0.7";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Idea from SF / Obsidian

STC
```
Elo   | -1.26 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 2.50]
Games | N: 29214 W: 7116 L: 7222 D: 14876
Penta | [80, 3539, 7468, 3447, 73]
https://furybench.com/test/1382/
```
LTC
```
Elo   | 1.73 +- 1.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 2.50]
Games | N: 61338 W: 15088 L: 14782 D: 31468
Penta | [28, 6741, 16824, 7049, 27]
https://furybench.com/test/1373/
```

Bench: 2191101