### PR TITLE
Do a small amount of LMR for captures in ttpv-allnodes

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.7";
+constexpr auto VERSION = "6.0.8";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.09 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 2.50]
Games | N: 49920 W: 12229 L: 11929 D: 25762
Penta | [135, 5763, 12884, 6023, 155]
https://furybench.com/test/1411/
```
LTC
```
Elo   | 3.26 +- 2.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.00 (-2.25, 2.89) [0.00, 2.50]
Games | N: 17250 W: 4247 L: 4085 D: 8918
Penta | [9, 1849, 4746, 2013, 8]
https://furybench.com/test/1413/
```

Bench: 2431890