### PR TITLE
Introduce fractional depth

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -205,7 +205,7 @@ void History::updateSingleCaptureHistory(Board* board, Move move, int16_t bonus)
     *captHistScore += scaledBonus;
 }
 
-void History::updateCaptureHistory(int depth, Board* board, Move move, int moveSearchCount, Move* captureMoves, int* captureSearchCount, int captureMoveCount) {
+void History::updateCaptureHistory(int16_t depth, Board* board, Move move, int moveSearchCount, Move* captureMoves, int* captureSearchCount, int captureMoveCount) {
     int captHistBonus = std::min(historyBonusCaptureBase + historyBonusCaptureFactor * depth, historyBonusCaptureMax);
     int captHistMalus = std::min(historyMalusCaptureBase + historyMalusCaptureFactor * depth, historyMalusCaptureMax);
 
@@ -220,7 +220,7 @@ void History::updateCaptureHistory(int depth, Board* board, Move move, int moveS
     }
 }
 
-void History::updateQuietHistories(int depth, Board* board, SearchStack* stack, Move move, int moveSearchCount, Move* quietMoves, int* quietSearchCount, int quietMoveCount) {
+void History::updateQuietHistories(int16_t depth, Board* board, SearchStack* stack, Move move, int moveSearchCount, Move* quietMoves, int* quietSearchCount, int quietMoveCount) {
     int quietHistBonus = std::min(historyBonusQuietBase + historyBonusQuietFactor * depth, historyBonusQuietMax);
     int quietHistMalus = std::min(historyMalusQuietBase + historyMalusQuietFactor * depth, historyMalusQuietMax);
     int contHistBonus = std::min(historyBonusContinuationBase + historyBonusContinuationFactor * depth, historyBonusContinuationMax);

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -8,43 +8,43 @@
 #include "spsa.h"
 
 // Quiet history
-TUNE_INT(historyBonusQuietBase, 24, -500, 500);
-TUNE_INT(historyBonusQuietFactor, 227, 1, 500);
-TUNE_INT(historyBonusQuietMax, 1997, 32, 4096);
-TUNE_INT(historyMalusQuietBase, 69, -500, 500);
-TUNE_INT(historyMalusQuietFactor, 196, 1, 500);
-TUNE_INT(historyMalusQuietMax, 1583, 32, 4096);
+TUNE_INT(historyBonusQuietBase, 63, -500, 500);
+TUNE_INT(historyBonusQuietFactor, 233, 1, 500);
+TUNE_INT(historyBonusQuietMax, 1974, 32, 4096);
+TUNE_INT(historyMalusQuietBase, 82, -500, 500);
+TUNE_INT(historyMalusQuietFactor, 201, 1, 500);
+TUNE_INT(historyMalusQuietMax, 1556, 32, 4096);
 
 // Continuation history
-TUNE_INT(historyBonusContinuationBase, 0, -500, 500);
-TUNE_INT(historyBonusContinuationFactor, 216, 1, 500);
-TUNE_INT(historyBonusContinuationMax, 2316, 32, 4096);
-TUNE_INT(historyMalusContinuationBase, 94, -500, 500);
-TUNE_INT(historyMalusContinuationFactor, 211, 1, 500);
-TUNE_INT(historyMalusContinuationMax, 1556, 32, 4096);
+TUNE_INT(historyBonusContinuationBase, -39, -500, 500);
+TUNE_INT(historyBonusContinuationFactor, 211, 1, 500);
+TUNE_INT(historyBonusContinuationMax, 2318, 32, 4096);
+TUNE_INT(historyMalusContinuationBase, 107, -500, 500);
+TUNE_INT(historyMalusContinuationFactor, 206, 1, 500);
+TUNE_INT(historyMalusContinuationMax, 1467, 32, 4096);
 
 // Pawn history
-TUNE_INT(historyBonusPawnBase, -2, -500, 500);
-TUNE_INT(historyBonusPawnFactor, 203, 1, 500);
-TUNE_INT(historyBonusPawnMax, 2424, 32, 4096);
-TUNE_INT(historyMalusPawnBase, 64, -500, 500);
-TUNE_INT(historyMalusPawnFactor, 251, 1, 500);
-TUNE_INT(historyMalusPawnMax, 1909, 32, 4096);
+TUNE_INT(historyBonusPawnBase, 33, -500, 500);
+TUNE_INT(historyBonusPawnFactor, 188, 1, 500);
+TUNE_INT(historyBonusPawnMax, 2464, 32, 4096);
+TUNE_INT(historyMalusPawnBase, 96, -500, 500);
+TUNE_INT(historyMalusPawnFactor, 250, 1, 500);
+TUNE_INT(historyMalusPawnMax, 1911, 32, 4096);
 
 // Capture history
-TUNE_INT(historyBonusCaptureBase, 31, -500, 500);
-TUNE_INT(historyBonusCaptureFactor, 141, 1, 500);
-TUNE_INT(historyBonusCaptureMax, 1834, 32, 4096);
-TUNE_INT(historyMalusCaptureBase, 150, -500, 500);
-TUNE_INT(historyMalusCaptureFactor, 243, 1, 500);
-TUNE_INT(historyMalusCaptureMax, 1904, 32, 4096);
+TUNE_INT(historyBonusCaptureBase, 0, -500, 500);
+TUNE_INT(historyBonusCaptureFactor, 136, 1, 500);
+TUNE_INT(historyBonusCaptureMax, 1803, 32, 4096);
+TUNE_INT(historyMalusCaptureBase, 114, -500, 500);
+TUNE_INT(historyMalusCaptureFactor, 245, 1, 500);
+TUNE_INT(historyMalusCaptureMax, 1970, 32, 4096);
 
 // Correction history
-TUNE_INT(pawnCorrectionFactor, 5920, 1000, 7500);
-TUNE_INT(nonPawnCorrectionFactor, 5576, 1000, 7500);
-TUNE_INT(minorCorrectionFactor, 3681, 1000, 7500);
-TUNE_INT(majorCorrectionFactor, 3125, 1000, 7500);
-TUNE_INT(continuationCorrectionFactor, 5129, 1000, 7500);
+TUNE_INT(pawnCorrectionFactor, 5852, 1000, 7500);
+TUNE_INT(nonPawnCorrectionFactor, 5620, 1000, 7500);
+TUNE_INT(minorCorrectionFactor, 3699, 1000, 7500);
+TUNE_INT(majorCorrectionFactor, 3055, 1000, 7500);
+TUNE_INT(continuationCorrectionFactor, 5281, 1000, 7500);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -8,43 +8,43 @@
 #include "spsa.h"
 
 // Quiet history
-TUNE_INT(historyBonusQuietBase, 63, -500, 500);
-TUNE_INT(historyBonusQuietFactor, 233, 1, 500);
-TUNE_INT(historyBonusQuietMax, 1974, 32, 4096);
-TUNE_INT(historyMalusQuietBase, 82, -500, 500);
-TUNE_INT(historyMalusQuietFactor, 201, 1, 500);
-TUNE_INT(historyMalusQuietMax, 1556, 32, 4096);
+TUNE_INT(historyBonusQuietBase, 61, -500, 500);
+TUNE_INT(historyBonusQuietFactor, 239, 1, 500);
+TUNE_INT(historyBonusQuietMax, 1977, 32, 4096);
+TUNE_INT(historyMalusQuietBase, 69, -500, 500);
+TUNE_INT(historyMalusQuietFactor, 213, 1, 500);
+TUNE_INT(historyMalusQuietMax, 1564, 32, 4096);
 
 // Continuation history
-TUNE_INT(historyBonusContinuationBase, -39, -500, 500);
-TUNE_INT(historyBonusContinuationFactor, 211, 1, 500);
-TUNE_INT(historyBonusContinuationMax, 2318, 32, 4096);
-TUNE_INT(historyMalusContinuationBase, 107, -500, 500);
-TUNE_INT(historyMalusContinuationFactor, 206, 1, 500);
-TUNE_INT(historyMalusContinuationMax, 1467, 32, 4096);
+TUNE_INT(historyBonusContinuationBase, -56, -500, 500);
+TUNE_INT(historyBonusContinuationFactor, 197, 1, 500);
+TUNE_INT(historyBonusContinuationMax, 2420, 32, 4096);
+TUNE_INT(historyMalusContinuationBase, 95, -500, 500);
+TUNE_INT(historyMalusContinuationFactor, 207, 1, 500);
+TUNE_INT(historyMalusContinuationMax, 1308, 32, 4096);
 
 // Pawn history
-TUNE_INT(historyBonusPawnBase, 33, -500, 500);
-TUNE_INT(historyBonusPawnFactor, 188, 1, 500);
-TUNE_INT(historyBonusPawnMax, 2464, 32, 4096);
-TUNE_INT(historyMalusPawnBase, 96, -500, 500);
-TUNE_INT(historyMalusPawnFactor, 250, 1, 500);
-TUNE_INT(historyMalusPawnMax, 1911, 32, 4096);
+TUNE_INT(historyBonusPawnBase, 14, -500, 500);
+TUNE_INT(historyBonusPawnFactor, 180, 1, 500);
+TUNE_INT(historyBonusPawnMax, 2425, 32, 4096);
+TUNE_INT(historyMalusPawnBase, 82, -500, 500);
+TUNE_INT(historyMalusPawnFactor, 268, 1, 500);
+TUNE_INT(historyMalusPawnMax, 2049, 32, 4096);
 
 // Capture history
-TUNE_INT(historyBonusCaptureBase, 0, -500, 500);
-TUNE_INT(historyBonusCaptureFactor, 136, 1, 500);
-TUNE_INT(historyBonusCaptureMax, 1803, 32, 4096);
-TUNE_INT(historyMalusCaptureBase, 114, -500, 500);
-TUNE_INT(historyMalusCaptureFactor, 245, 1, 500);
-TUNE_INT(historyMalusCaptureMax, 1970, 32, 4096);
+TUNE_INT(historyBonusCaptureBase, 15, -500, 500);
+TUNE_INT(historyBonusCaptureFactor, 124, 1, 500);
+TUNE_INT(historyBonusCaptureMax, 1732, 32, 4096);
+TUNE_INT(historyMalusCaptureBase, 127, -500, 500);
+TUNE_INT(historyMalusCaptureFactor, 236, 1, 500);
+TUNE_INT(historyMalusCaptureMax, 2092, 32, 4096);
 
 // Correction history
-TUNE_INT(pawnCorrectionFactor, 5852, 1000, 7500);
-TUNE_INT(nonPawnCorrectionFactor, 5620, 1000, 7500);
-TUNE_INT(minorCorrectionFactor, 3699, 1000, 7500);
-TUNE_INT(majorCorrectionFactor, 3055, 1000, 7500);
-TUNE_INT(continuationCorrectionFactor, 5281, 1000, 7500);
+TUNE_INT(pawnCorrectionFactor, 5969, 1000, 7500);
+TUNE_INT(nonPawnCorrectionFactor, 5638, 1000, 7500);
+TUNE_INT(minorCorrectionFactor, 3630, 1000, 7500);
+TUNE_INT(majorCorrectionFactor, 2931, 1000, 7500);
+TUNE_INT(continuationCorrectionFactor, 5269, 1000, 7500);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/history.h
+++ b/src/history.h
@@ -44,9 +44,9 @@ public:
 
     int16_t* getCaptureHistory(Board* board, Move move);
     void updateSingleCaptureHistory(Board* board, Move move, int16_t bonus);
-    void updateCaptureHistory(int depth, Board* board, Move move, int moveSearchCount, Move* captureMoves, int* captureSearchCount, int captureMoveCount);
+    void updateCaptureHistory(int16_t depth, Board* board, Move move, int moveSearchCount, Move* captureMoves, int* captureSearchCount, int captureMoveCount);
 
-    void updateQuietHistories(int depth, Board* board, SearchStack* stack, Move move, int moveSearchCount, Move* quietMoves, int* quietSearchCount, int quietMoveCount);
+    void updateQuietHistories(int16_t depth, Board* board, SearchStack* stack, Move move, int moveSearchCount, Move* quietMoves, int* quietSearchCount, int quietMoveCount);
 
     Move getCounterMove(Move move);
     void setCounterMove(Move move, Move counter);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -267,17 +267,17 @@ void generateMoves(Board* board, Move* moves, int* counter, bool onlyCaptures) {
 }
 
 // Main search
-MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(false), killer(searchStack->killer), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0), skipQuiets(false) {
+MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int16_t depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(false), killer(searchStack->killer), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0), skipQuiets(false) {
     counterMove = searchStack->ply > 0 ? history->getCounterMove((searchStack - 1)->move) : MOVE_NONE;
 }
 
 // qSearch
-MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(onlyCaptures), killer(MOVE_NONE), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0), skipQuiets(false) {
+MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int16_t depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(onlyCaptures), killer(MOVE_NONE), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(false), probCutThreshold(0), skipQuiets(false) {
     counterMove = onlyCaptures || searchStack->ply == 0 ? MOVE_NONE : history->getCounterMove((searchStack - 1)->move);
 }
 
 // ProbCut
-MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int probCutThreshold, int depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(true), killer(MOVE_NONE), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(true), probCutThreshold(probCutThreshold), skipQuiets(false) {
+MoveGen::MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int probCutThreshold, int16_t depth) : board(board), history(history), searchStack(searchStack), ttMove(ttMove), onlyCaptures(true), killer(MOVE_NONE), moveList{ MOVE_NONE }, generatedMoves(0), returnedMoves(0), badCaptureList{ MOVE_NONE }, generatedBadCaptures(0), returnedBadCaptures(0), stage(STAGE_TTMOVE), depth(depth), probCut(true), probCutThreshold(probCutThreshold), skipQuiets(false) {
     counterMove = MOVE_NONE;
 }
 

--- a/src/move.h
+++ b/src/move.h
@@ -76,7 +76,7 @@ class MoveGen {
     int returnedBadCaptures;
 
     MoveGenStage stage;
-    int depth;
+    int16_t depth;
 
     bool probCut;
     int probCutThreshold;
@@ -86,11 +86,11 @@ public:
     bool skipQuiets;
 
     // Main search
-    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int depth);
+    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int16_t depth);
     // qSearch
-    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int depth);
+    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, bool onlyCaptures, int16_t depth);
     // ProbCut
-    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int probCutThreshold, int depth);
+    MoveGen(Board* board, History* history, SearchStack* searchStack, Move ttMove, int probCutThreshold, int16_t depth);
 
     Move nextMove();
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -615,7 +615,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth + 50 + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth - 50 + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,6 +63,7 @@ TUNE_INT(qsFutilityOffset, 68, 1, 125);
 TUNE_INT(qsSeeMargin, -82, -200, 50);
 
 // Pre-search pruning
+TUNE_INT(ttCutOffset, 50, -100, 200);
 TUNE_INT(ttCutFailHighMargin, 100, 0, 200);
 
 TUNE_INT(iirMinDepth, 379, 100, 1000);
@@ -634,7 +635,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth - 50 + ttCutFailHighMargin * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth - ttCutOffset + ttCutFailHighMargin * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -39,118 +39,118 @@ TUNE_FLOAT_DISABLED(tmNodesFactor, 0.9741686475516691f, 0.1f, 2.5f);
 TUNE_INT_DISABLED(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT_DISABLED(aspirationWindowDelta, 14, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowDeltaBase, 10, 1, 30);
-TUNE_INT(aspirationWindowDeltaDivisor, 12681, 7500, 17500);
+TUNE_INT(aspirationWindowDeltaDivisor, 12867, 7500, 17500);
 TUNE_INT_DISABLED(aspirationWindowMaxFailHighs, 3, 1, 10);
 TUNE_FLOAT_DISABLED(aspirationWindowDeltaFactor, 1.5804938062670641f, 1.0f, 3.0f);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.15479789310247533f, -2.0f, -0.1f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.3112850174104427f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 1.1379245400518583f, 0.50f, 1.5f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.8997689712710466f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.1469526773526456f, -2.0f, -0.1f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 3.2913929348541524f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 1.1249164313513371f, 0.50f, 1.5f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.9803357858847743f, 2.0f, 4.0f);
 
-TUNE_FLOAT(seeMarginNoisy, -24.40422689842072f, -50.0f, -10.0f);
-TUNE_FLOAT(seeMarginQuiet, -77.46039783122589f, -100.0f, -50.0f);
-TUNE_FLOAT(lmpMarginWorseningBase, 1.932336729298966f, -1.0f, 2.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.4372991933478511f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.660804390081005f, 1.0f, 3.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 2.7242843289961067f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 0.8277962583165434f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 1.9124128409053007f, 1.0f, 3.0f);
+TUNE_FLOAT(seeMarginNoisy, -21.896447313366288f, -50.0f, -10.0f);
+TUNE_FLOAT(seeMarginQuiet, -76.08383333556118f, -100.0f, -50.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.8740227708454298f, -1.0f, 2.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.47626879982753145f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.588444328682528f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 2.5759702639663975f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 0.867434947078185f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 1.9225038758479083f, 1.0f, 3.0f);
 
 // Search values
 TUNE_INT(qsFutilityOffset, 68, 1, 125);
-TUNE_INT(qsSeeMargin, -87, -200, 50);
+TUNE_INT(qsSeeMargin, -82, -200, 50);
 
 // Pre-search pruning
 TUNE_INT(ttCutFailHighMargin, 100, 0, 200);
 
-TUNE_INT(iirMinDepth, 400, 100, 1000);
-TUNE_INT(iirLowTtDepthOffset, 400, 0, 800);
-TUNE_INT(iirReduction, 100, 0, 200);
+TUNE_INT(iirMinDepth, 379, 100, 1000);
+TUNE_INT(iirLowTtDepthOffset, 414, 0, 800);
+TUNE_INT(iirReduction, 95, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -61, -500, -1);
-TUNE_INT(staticHistoryMin, -161, -1000, -1);
-TUNE_INT(staticHistoryMax, 170, 1, 1000);
-TUNE_INT(staticHistoryTempo, 36, 1, 1000);
+TUNE_INT(staticHistoryFactor, -65, -500, -1);
+TUNE_INT(staticHistoryMin, -179, -1000, -1);
+TUNE_INT(staticHistoryMax, 164, 1, 1000);
+TUNE_INT(staticHistoryTempo, 26, 1, 1000);
 
-TUNE_INT(rfpDepth, 800, 200, 2000);
-TUNE_INT(rfpFactor, 96, 1, 250);
+TUNE_INT(rfpDepth, 843, 200, 2000);
+TUNE_INT(rfpFactor, 88, 1, 250);
 
-TUNE_INT(razoringDepth, 400, 200, 2000);
-TUNE_INT(razoringFactor, 284, 1, 1000);
+TUNE_INT(razoringDepth, 421, 200, 2000);
+TUNE_INT(razoringFactor, 285, 1, 1000);
 
-TUNE_INT(nmpMinDepth, 300, 0, 600);
-TUNE_INT(nmpRedBase, 400, 100, 800);
-TUNE_INT(nmpDepthDiv, 300, 100, 600);
+TUNE_INT(nmpMinDepth, 323, 0, 600);
+TUNE_INT(nmpRedBase, 398, 100, 800);
+TUNE_INT(nmpDepthDiv, 308, 100, 600);
 TUNE_INT(nmpMin, 400, 100, 800);
-TUNE_INT(nmpDivisor, 174, 10, 1000);
-TUNE_INT(nmpEvalDepth, 18, 1, 100);
+TUNE_INT(nmpDivisor, 199, 10, 1000);
+TUNE_INT(nmpEvalDepth, 14, 1, 100);
 TUNE_INT(nmpEvalBase, 173, 50, 300);
 
-TUNE_INT(probCutBetaOffset, 205, 1, 500);
-TUNE_INT(probCutDepth, 500, 100, 1000);
+TUNE_INT(probCutBetaOffset, 207, 1, 500);
+TUNE_INT(probCutDepth, 481, 100, 1000);
 
-TUNE_INT(iir2Reduction, 100, 0, 200);
+TUNE_INT(iir2Reduction, 101, 0, 200);
 
 // In-search pruning
-TUNE_INT(earlyLmrReductionTableFactor, 101, 100, 200);
+TUNE_INT(earlyLmrReductionTableFactor, 102, 100, 200);
 
-TUNE_INT(earlyLmrHistoryFactorQuiet, 16009, 10000, 20000);
-TUNE_INT(earlyLmrHistoryFactorCapture, 14637, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorQuiet, 16131, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorCapture, 14641, 10000, 20000);
 
-TUNE_INT(fpDepth, 1100, 100, 2000);
-TUNE_INT(fpBase, 206, 1, 1000);
-TUNE_INT(fpFactor, 101, 1, 500);
+TUNE_INT(fpDepth, 1129, 100, 2000);
+TUNE_INT(fpBase, 251, 1, 1000);
+TUNE_INT(fpFactor, 103, 1, 500);
 
-TUNE_INT(fpCaptDepth, 900, 100, 2000);
-TUNE_INT(fpCaptBase, 403, 150, 750);
-TUNE_INT(fpCaptFactor, 403, 100, 600);
+TUNE_INT(fpCaptDepth, 911, 100, 2000);
+TUNE_INT(fpCaptBase, 419, 150, 750);
+TUNE_INT(fpCaptFactor, 416, 100, 600);
 
-TUNE_INT(historyPruningDepth, 400, 100, 1000);
-TUNE_INT(historyPruningFactorCapture, -1879, -8192, -128);
-TUNE_INT(historyPruningFactorQuiet, -6129, -8192, -128);
+TUNE_INT(historyPruningDepth, 435, 100, 1000);
+TUNE_INT(historyPruningFactorCapture, -1723, -8192, -128);
+TUNE_INT(historyPruningFactorQuiet, -6292, -8192, -128);
 
-TUNE_INT(extensionMinDepth, 600, 0, 1200);
-TUNE_INT(extensionTtDepthOffset, 300, 0, 600);
-TUNE_INT(doubleExtensionDepthIncreaseFactor, 100, 0, 200);
+TUNE_INT(extensionMinDepth, 629, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 350, 0, 600);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 96, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
 TUNE_INT_DISABLED(doubleExtensionDepthIncrease, 1100, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT(lmrMinDepth, 300, 100, 600);
+TUNE_INT(lmrMinDepth, 291, 100, 600);
 
-TUNE_INT(lmrCheck, 88, 0, 500);
-TUNE_INT(lmrTtPv, 194, 0, 500);
-TUNE_INT(lmrCutnode, 184, 0, 500);
-TUNE_INT(lmrTtpvFaillow, 89, 0, 500);
-TUNE_INT(lmrCorrection, 151620, 10000, 200000);
-TUNE_INT(lmrHistoryFactorQuiet, 25301, 10000, 30000);
-TUNE_INT(lmrHistoryFactorCapture, 3099400, 2500000, 4000000);
+TUNE_INT(lmrCheck, 81, 0, 500);
+TUNE_INT(lmrTtPv, 192, 0, 500);
+TUNE_INT(lmrCutnode, 206, 0, 500);
+TUNE_INT(lmrTtpvFaillow, 84, 0, 500);
+TUNE_INT(lmrCorrection, 145323, 10000, 200000);
+TUNE_INT(lmrHistoryFactorQuiet, 26936, 10000, 30000);
+TUNE_INT(lmrHistoryFactorCapture, 3068010, 2500000, 4000000);
 
-TUNE_INT(postlmrOppWorseningThreshold, 303, 150, 450);
-TUNE_INT(postlmrOppWorseningReduction, 100, 0, 200);
+TUNE_INT(postlmrOppWorseningThreshold, 310, 150, 450);
+TUNE_INT(postlmrOppWorseningReduction, 112, 0, 200);
 
-TUNE_INT(lmrPvNodeExtension, 100, 0, 200);
+TUNE_INT(lmrPvNodeExtension, 104, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
-TUNE_INT(lmrDeeperWeight, 100, 0, 200);
-TUNE_INT(lmrShallowerWeight, 100, 0, 200);
-TUNE_INT(lmrResearchSkipDepthOffset, 400, 0, 800);
+TUNE_INT(lmrDeeperWeight, 107, 0, 200);
+TUNE_INT(lmrShallowerWeight, 102, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 396, 0, 800);
 
-TUNE_INT(lmrPassBonusBase, -311, -500, 500);
-TUNE_INT(lmrPassBonusFactor, 190, 1, 500);
-TUNE_INT(lmrPassBonusMax, 1023, 32, 4096);
+TUNE_INT(lmrPassBonusBase, -310, -500, 500);
+TUNE_INT(lmrPassBonusFactor, 177, 1, 500);
+TUNE_INT(lmrPassBonusMax, 1025, 32, 4096);
 
-TUNE_INT(historyDepthBetaOffset, 247, 1, 500);
+TUNE_INT(historyDepthBetaOffset, 248, 1, 500);
 
-TUNE_INT(lowDepthPvDepthReductionMin, 400, 0, 800);
-TUNE_INT(lowDepthPvDepthReductionMax, 1000, 0, 2000);
-TUNE_INT(lowDepthPvDepthReductionWeight, 100, 0, 200);
+TUNE_INT(lowDepthPvDepthReductionMin, 403, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1008, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 99, 0, 200);
 
-TUNE_INT(correctionHistoryFactor, 163, 32, 512);
+TUNE_INT(correctionHistoryFactor, 169, 32, 512);
 
 int REDUCTIONS[2][MAX_PLY][MAX_MOVES];
 int SEE_MARGIN[MAX_PLY][2];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,44 +63,44 @@ TUNE_INT(qsFutilityOffset, 68, 1, 125);
 TUNE_INT(qsSeeMargin, -87, -200, 50);
 
 // Pre-search pruning
-TUNE_INT_DISABLED(iirMinDepth, 4, 1, 10);
+TUNE_INT_DISABLED(iirMinDepth, 400, 100, 1000);
 
 TUNE_INT(staticHistoryFactor, -61, -500, -1);
 TUNE_INT(staticHistoryMin, -161, -1000, -1);
 TUNE_INT(staticHistoryMax, 170, 1, 1000);
 TUNE_INT(staticHistoryTempo, 36, 1, 1000);
 
-TUNE_INT_DISABLED(rfpDepth, 8, 2, 20);
+TUNE_INT_DISABLED(rfpDepth, 800, 200, 2000);
 TUNE_INT(rfpFactor, 96, 1, 250);
 
-TUNE_INT_DISABLED(razoringDepth, 5, 2, 20);
+TUNE_INT_DISABLED(razoringDepth, 400, 200, 2000);
 TUNE_INT(razoringFactor, 284, 1, 1000);
 
-TUNE_INT_DISABLED(nmpRedBase, 4, 1, 5);
+TUNE_INT_DISABLED(nmpRedBase, 400, 100, 800);
 TUNE_INT_DISABLED(nmpDepthDiv, 3, 1, 6);
-TUNE_INT_DISABLED(nmpMin, 4, 1, 10);
+TUNE_INT_DISABLED(nmpMin, 400, 1, 10);
 TUNE_INT(nmpDivisor, 174, 10, 1000);
 TUNE_INT(nmpEvalDepth, 18, 1, 100);
 TUNE_INT(nmpEvalBase, 173, 50, 300);
 
 TUNE_INT(probCutBetaOffset, 205, 1, 500);
-TUNE_INT_DISABLED(probCutDepth, 5, 1, 15);
+TUNE_INT_DISABLED(probCutDepth, 500, 100, 1000);
 
 // In-search pruning
-TUNE_INT(earlyLmrReductionTableFactor, 1014, 500, 2000);
+TUNE_INT(earlyLmrReductionTableFactor, 101, 500, 2000);
 
 TUNE_INT(earlyLmrHistoryFactorQuiet, 16009, 10000, 20000);
 TUNE_INT(earlyLmrHistoryFactorCapture, 14637, 10000, 20000);
 
-TUNE_INT_DISABLED(fpDepth, 11, 1, 20);
+TUNE_INT_DISABLED(fpDepth, 1100, 100, 2000);
 TUNE_INT(fpBase, 206, 1, 1000);
 TUNE_INT(fpFactor, 101, 1, 500);
 
-TUNE_INT_DISABLED(fpCaptDepth, 9, 1, 20);
+TUNE_INT_DISABLED(fpCaptDepth, 900, 100, 2000);
 TUNE_INT(fpCaptBase, 403, 150, 750);
 TUNE_INT(fpCaptFactor, 403, 100, 600);
 
-TUNE_INT_DISABLED(historyPruningDepth, 4, 1, 15);
+TUNE_INT_DISABLED(historyPruningDepth, 400, 100, 1000);
 TUNE_INT(historyPruningFactorCapture, -1879, -8192, -128);
 TUNE_INT(historyPruningFactorQuiet, -6129, -8192, -128);
 
@@ -110,17 +110,17 @@ TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT_DISABLED(lmrMinDepth, 3, 1, 10);
+TUNE_INT_DISABLED(lmrMinDepth, 300, 100, 600);
 
-TUNE_INT(lmrCheck, 881, 0, 5000);
-TUNE_INT(lmrTtPv, 1943, 0, 5000);
-TUNE_INT(lmrCutnode, 1841, 0, 5000);
-TUNE_INT(lmrTtpvFaillow, 889, 0, 5000);
-TUNE_INT(lmrCorrection, 15162, 1000, 20000);
+TUNE_INT(lmrCheck, 88, 0, 500);
+TUNE_INT(lmrTtPv, 194, 0, 500);
+TUNE_INT(lmrCutnode, 184, 0, 500);
+TUNE_INT(lmrTtpvFaillow, 89, 0, 500);
+TUNE_INT(lmrCorrection, 151620, 10000, 200000);
 TUNE_INT(lmrHistoryFactorQuiet, 25301, 10000, 30000);
-TUNE_INT(lmrHistoryFactorCapture, 309944, 250000, 400000);
+TUNE_INT(lmrHistoryFactorCapture, 3099400, 2500000, 4000000);
 
-TUNE_INT(postlmrOppWorseningThreshold, 3031, 1500, 4500);
+TUNE_INT(postlmrOppWorseningThreshold, 303, 150, 450);
 
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
@@ -143,12 +143,12 @@ void initReductions() {
 
     for (int i = 1; i < MAX_PLY; i++) {
         for (int j = 1; j < MAX_MOVES; j++) {
-            REDUCTIONS[0][i][j] = 1000 * (lmrReductionNoisyBase + log(i) * log(j) / lmrReductionNoisyFactor); // non-quiet
-            REDUCTIONS[1][i][j] = 1000 * (lmrReductionQuietBase + log(i) * log(j) / lmrReductionQuietFactor); // quiet
+            REDUCTIONS[0][i][j] = 100 * (lmrReductionNoisyBase + log(i) * log(j) / lmrReductionNoisyFactor); // non-quiet
+            REDUCTIONS[1][i][j] = 100 * (lmrReductionQuietBase + log(i) * log(j) / lmrReductionQuietFactor); // quiet
         }
     }
 
-    for (int depth = 0; depth < MAX_PLY; depth++) {
+    for (int16_t depth = 0; depth < MAX_PLY; depth++) {
         SEE_MARGIN[depth][0] = seeMarginNoisy * depth * depth; // non-quiet
         SEE_MARGIN[depth][1] = seeMarginQuiet * depth; // quiet
 
@@ -157,7 +157,7 @@ void initReductions() {
     }
 }
 
-uint64_t perftInternal(Board& board, NNUE* nnue, int depth) {
+uint64_t perftInternal(Board& board, NNUE* nnue, int16_t depth) {
     if (depth == 0) return 1;
 
     Move moves[MAX_MOVES] = { MOVE_NONE };
@@ -181,7 +181,7 @@ uint64_t perftInternal(Board& board, NNUE* nnue, int depth) {
     return nodes;
 }
 
-uint64_t perft(Board& board, int depth) {
+uint64_t perft(Board& board, int16_t depth) {
     clock_t begin = clock();
     UCI::nnue.reset(&board);
 
@@ -541,7 +541,7 @@ movesLoopQsearch:
 }
 
 template <NodeType nt>
-Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eval beta, bool cutNode) {
+Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha, Eval beta, bool cutNode) {
     constexpr bool rootNode = nt == ROOT_NODE;
     constexpr bool pvNode = nt == PV_NODE || nt == ROOT_NODE;
     constexpr NodeType nodeType = nt == ROOT_NODE ? PV_NODE : NON_PV_NODE;
@@ -562,8 +562,8 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
             return alpha;
     }
 
-    if (depth <= 0) return qsearch<nodeType>(board, stack, alpha, beta);
-    if (depth >= MAX_PLY - 1) depth = MAX_PLY - 1;
+    if (depth < 100) return qsearch<nodeType>(board, stack, alpha, beta);
+    if (depth >= MAX_DEPTH) depth = MAX_DEPTH;
 
     if (!rootNode) {
 
@@ -615,7 +615,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth + (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe
@@ -712,25 +712,25 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     }
 
     // IIR
-    if ((!ttHit || ttDepth + 4 < depth) && depth >= iirMinDepth)
-        depth--;
+    if ((!ttHit || ttDepth + 400 < depth) && depth >= iirMinDepth)
+        depth -= 100;
 
     // Post-LMR depth adjustments
     if ((stack - 1)->inLMR) {
         int additionalReduction = 0;
         if ((stack - 1)->reduction >= postlmrOppWorseningThreshold && stack->staticEval <= -(stack - 1)->staticEval)
-            additionalReduction--;
+            additionalReduction -= 100;
 
         depth -= additionalReduction;
-        (stack - 1)->reduction += 1000 * additionalReduction;
+        (stack - 1)->reduction += additionalReduction;
     }
 
     // Reverse futility pruning
-    if (!rootNode && depth < rfpDepth && std::abs(eval) < EVAL_TBWIN_IN_MAX_PLY && eval - rfpFactor * (depth - (improving && !board->opponentHasGoodCapture())) >= beta)
+    if (!rootNode && depth <= rfpDepth && std::abs(eval) < EVAL_TBWIN_IN_MAX_PLY && eval - rfpFactor * (depth - 100 * (improving && !board->opponentHasGoodCapture())) / 100 >= beta)
         return std::min((eval + beta) / 2, EVAL_TBWIN_IN_MAX_PLY - 1);
 
     // Razoring
-    if (!rootNode && depth < razoringDepth && eval + (razoringFactor * depth) < alpha && alpha < EVAL_TBWIN_IN_MAX_PLY) {
+    if (!rootNode && depth <= razoringDepth && eval + (razoringFactor * depth) / 100 < alpha && alpha < EVAL_TBWIN_IN_MAX_PLY) {
         Eval razorValue = qsearch<NON_PV_NODE>(board, stack, alpha, beta);
         if (razorValue <= alpha && std::abs(razorValue) < EVAL_TBWIN_IN_MAX_PLY)
             return razorValue;
@@ -740,11 +740,11 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
     if (!pvNode
         && eval >= beta
         && eval >= stack->staticEval
-        && stack->staticEval + nmpEvalDepth * depth - nmpEvalBase >= beta
+        && stack->staticEval + nmpEvalDepth * depth / 100 - nmpEvalBase >= beta
         && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY
         && !excluded
         && (stack - 1)->movedPiece != Piece::NONE
-        && depth >= 3
+        && depth >= 300
         && stack->ply >= searchData.nmpPlies
         && board->hasNonPawns()
         ) {
@@ -753,7 +753,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
         stack->movedPiece = Piece::NONE;
         stack->contHist = history.continuationHistory[board->stm][0][0];
         stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][0][0];
-        int R = nmpRedBase + depth / nmpDepthDiv + std::min((eval - beta) / nmpDivisor, nmpMin);
+        int R = nmpRedBase + depth / nmpDepthDiv + std::min(100 * (eval - beta) / nmpDivisor, nmpMin);
 
         Board* boardCopy = doNullMove(board);
         Eval nullValue = -search<NON_PV_NODE>(boardCopy, stack + 1, depth - R, -beta, -beta + 1, !cutNode);
@@ -766,10 +766,10 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
             if (nullValue >= EVAL_TBWIN_IN_MAX_PLY)
                 nullValue = beta;
 
-            if (searchData.nmpPlies || depth < 15)
+            if (searchData.nmpPlies || depth < 1500)
                 return nullValue;
 
-            searchData.nmpPlies = stack->ply + (depth - R) * 2 / 3;
+            searchData.nmpPlies = stack->ply + (depth - R) * 2 / 300;
             Eval verificationValue = search<NON_PV_NODE>(board, stack, depth - R, beta - 1, beta, false);
             searchData.nmpPlies = 0;
 
@@ -784,13 +784,13 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
         && !excluded
         && depth > probCutDepth
         && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY - 1
-        && !(ttDepth >= depth - 3 && ttValue != EVAL_NONE && ttValue < probCutBeta)) {
+        && !(ttDepth >= depth - 300 && ttValue != EVAL_NONE && ttValue < probCutBeta)) {
 
         assert(probCutBeta > beta);
         assert(probCutBeta < EVAL_TBWIN_IN_MAX_PLY);
 
         Move probcutTtMove = ttMove != MOVE_NONE && board->isPseudoLegal(ttMove) && SEE(board, ttMove, probCutBeta - stack->staticEval) ? ttMove : MOVE_NONE;
-        MoveGen movegen(board, &history, stack, probcutTtMove, probCutBeta - stack->staticEval, depth);
+        MoveGen movegen(board, &history, stack, probcutTtMove, probCutBeta - stack->staticEval, depth / 100);
         Move move;
         while ((move = movegen.nextMove()) != MOVE_NONE) {
             if (move == excludedMove || !board->isLegal(move))
@@ -812,7 +812,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
             Eval value = -qsearch<NON_PV_NODE>(boardCopy, stack + 1, -probCutBeta, -probCutBeta + 1);
 
             if (value >= probCutBeta)
-                value = -search<NON_PV_NODE>(boardCopy, stack + 1, depth - 4, -probCutBeta, -probCutBeta + 1, !cutNode);
+                value = -search<NON_PV_NODE>(boardCopy, stack + 1, depth - 400, -probCutBeta, -probCutBeta + 1, !cutNode);
 
             undoMove();
 
@@ -821,7 +821,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
             if (value >= probCutBeta) {
                 value = std::min(value, EVAL_TBWIN_IN_MAX_PLY - 1);
-                ttEntry->update(board->hashes.hash, move, depth - 3, unadjustedEval, valueToTT(value, stack->ply), stack->ttPv, TT_LOWERBOUND);
+                ttEntry->update(board->hashes.hash, move, depth - 300, unadjustedEval, valueToTT(value, stack->ply), stack->ttPv, TT_LOWERBOUND);
                 return value;
             }
         }
@@ -830,7 +830,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int depth, Eval alpha, Eva
 
     // IIR 2: Electric boolagoo
     if (!ttHit && depth >= iirMinDepth && pvNode)
-        depth--;
+        depth -= 100;
 
 movesLoop:
 
@@ -845,7 +845,7 @@ movesLoop:
     int captureMoveCount = 0;
 
     // Moves loop
-    MoveGen movegen(board, &history, stack, ttMove, depth);
+    MoveGen movegen(board, &history, stack, ttMove, depth / 100);
     Move move;
     int moveCount = 0;
     while ((move = movegen.nextMove()) != MOVE_NONE) {
@@ -868,17 +868,17 @@ movesLoop:
             && board->hasNonPawns()
             ) {
 
-            int lmrDepth = std::max(0, depth - earlyLmrReductionTableFactor * REDUCTIONS[!capture][depth][moveCount] / 1000000 - !improving + moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
+            int16_t lmrDepth = std::max(0, depth - earlyLmrReductionTableFactor * REDUCTIONS[!capture][depth / 100][moveCount] / 100 - 100 * !improving + 100 * moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
 
             if (!pvNode && !movegen.skipQuiets) {
 
                 // Movecount pruning (LMP)
-                if (moveCount >= LMP_MARGIN[depth][improving]) {
+                if (moveCount >= LMP_MARGIN[depth / 100][improving]) {
                     movegen.skipQuietMoves();
                 }
 
                 // Futility pruning
-                if (!capture && lmrDepth < fpDepth && eval + fpBase + fpFactor * lmrDepth <= alpha) {
+                if (!capture && lmrDepth < fpDepth && eval + fpBase + fpFactor * lmrDepth / 100 <= alpha) {
                     movegen.skipQuietMoves();
                 }
             }
@@ -886,19 +886,19 @@ movesLoop:
             // Futility pruning for captures
             if (!pvNode && capture && moveType(move) != MOVE_PROMOTION) {
                 Piece capturedPiece = moveType(move) == MOVE_ENPASSANT ? Piece::PAWN : board->pieces[moveTarget(move)];
-                if (lmrDepth < fpCaptDepth && eval + fpCaptBase + PIECE_VALUES[capturedPiece] + fpCaptFactor * lmrDepth <= alpha)
+                if (lmrDepth < fpCaptDepth && eval + fpCaptBase + PIECE_VALUES[capturedPiece] + fpCaptFactor * lmrDepth / 100 <= alpha)
                     continue;
             }
 
-            lmrDepth = std::min(std::min(depth + 1, MAX_PLY - 1), lmrDepth);
+            lmrDepth = std::min(std::min<int16_t>(depth + 100, MAX_DEPTH), lmrDepth);
 
             // History pruning
             int hpFactor = capture ? historyPruningFactorCapture : historyPruningFactorQuiet;
-            if (!pvNode && lmrDepth < historyPruningDepth && moveHistory < hpFactor * depth)
+            if (!pvNode && lmrDepth < historyPruningDepth && moveHistory < hpFactor * depth / 100)
                 continue;
 
             // SEE Pruning
-            if (!SEE(board, move, (2 + pvNode) * SEE_MARGIN[!capture ? lmrDepth : depth][!capture] / 2))
+            if (!SEE(board, move, (2 + pvNode) * SEE_MARGIN[!capture ? lmrDepth / 100 : depth / 100][!capture] / 2))
                 continue;
 
         }
@@ -907,14 +907,14 @@ movesLoop:
         bool doExtensions = !rootNode && stack->ply < searchData.rootDepth * 2;
         int extension = 0;
         if (doExtensions
-            && depth >= 6
+            && depth >= 600
             && move == ttMove
             && !excluded
             && (ttFlag & TT_LOWERBOUND)
             && std::abs(ttValue) < EVAL_TBWIN_IN_MAX_PLY
-            && ttDepth >= depth - 3
+            && ttDepth >= depth - 300
             ) {
-            Eval singularBeta = ttValue - (1 + (stack->ttPv && !pvNode)) * depth;
+            Eval singularBeta = ttValue - (1 + (stack->ttPv && !pvNode)) * depth / 100;
             int singularDepth = (depth - 1) / 2;
 
             bool currTtPv = stack->ttPv;
@@ -931,7 +931,7 @@ movesLoop:
                 extension = 1;
                 if (!pvNode && singularValue + doubleExtensionMargin < singularBeta) {
                     extension = 2;
-                    depth += depth < doubleExtensionDepthIncrease;
+                    depth += 100 * (depth < doubleExtensionDepthIncrease);
                     if (!board->isCapture(move) && singularValue + tripleExtensionMargin < singularBeta)
                         extension = 3;
                 }
@@ -983,12 +983,12 @@ movesLoop:
         Board* boardCopy = doMove(board, newHash, move);
 
         Eval value = 0;
-        int newDepth = depth - 1 + extension;
+        int newDepth = depth - 100 + 100 * extension;
 
         // Very basic LMR: Late moves are being searched with less depth
         // Check if the move can exceed alpha
         if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth && (!capture || !pvNode)) {
-            int reduction = REDUCTIONS[!capture][depth][moveCount];
+            int16_t reduction = REDUCTIONS[!capture][depth / 100][moveCount];
 
             if (stack->ttPv && !pvNode && !cutNode && capture) {
                 // Do very slight LMR for captures in ttPv-allnodes
@@ -1011,15 +1011,15 @@ movesLoop:
                 if (capture)
                     reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
                 else
-                    reduction -= 1000 * moveHistory / lmrHistoryFactorQuiet;
+                    reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
 
-            int reducedDepth = std::clamp(newDepth - reduction / 1000, 1, newDepth + pvNode);
+            int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100 * pvNode);
             stack->reduction = reduction;
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
             stack->inLMR = false;
-            reducedDepth = std::clamp(newDepth - stack->reduction / 1000, 1, newDepth + pvNode);
+            reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100 * pvNode);
             stack->reduction = 0;
 
             if (capture && captureMoveCount < 32)
@@ -1027,11 +1027,11 @@ movesLoop:
             else if (!capture && quietMoveCount < 32)
                 quietSearchCount[quietMoveCount]++;
 
-            bool doShallowerSearch = !rootNode && value < bestValue + newDepth;
-            bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth);
-            newDepth += doDeeperSearch - doShallowerSearch;
+            bool doShallowerSearch = !rootNode && value < bestValue + newDepth / 100;
+            bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth / 100);
+            newDepth += 100 * doDeeperSearch - 100 * doShallowerSearch;
 
-            if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - 4 >= newDepth && (ttFlag & TT_UPPERBOUND))) {
+            if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - 400 >= newDepth && (ttFlag & TT_UPPERBOUND))) {
                 value = -search<NON_PV_NODE>(boardCopy, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);
 
                 if (capture && captureMoveCount < 32)
@@ -1040,7 +1040,7 @@ movesLoop:
                     quietSearchCount[quietMoveCount]++;
 
                 if (!capture) {
-                    int bonus = std::min(lmrPassBonusBase + lmrPassBonusFactor * (value > alpha ? depth : reducedDepth), lmrPassBonusMax);
+                    int bonus = std::min(lmrPassBonusBase + lmrPassBonusFactor * (value > alpha ? depth / 100 : reducedDepth / 100), lmrPassBonusMax);
                     history.updateContinuationHistory(stack, board->stm, stack->movedPiece, move, bonus);
                 }
             }
@@ -1118,7 +1118,7 @@ movesLoop:
 
                 if (bestValue >= beta) {
 
-                    int historyUpdateDepth = depth + (eval <= alpha) + (value - historyDepthBetaOffset > beta);
+                    int historyUpdateDepth = depth / 100 + (eval <= alpha) + (value - historyDepthBetaOffset > beta);
 
                     if (!capture) {
                         // Update quiet killer
@@ -1135,8 +1135,8 @@ movesLoop:
                     break;
                 }
 
-                if (depth > 4 && depth < 10 && beta < EVAL_TBWIN_IN_MAX_PLY && value > -EVAL_TBWIN_IN_MAX_PLY)
-                    depth--;
+                if (depth > 400 && depth < 1000 && beta < EVAL_TBWIN_IN_MAX_PLY && value > -EVAL_TBWIN_IN_MAX_PLY)
+                    depth -= 100;
             }
         }
 
@@ -1146,7 +1146,7 @@ movesLoop:
         return 0;
 
     if (!pvNode && bestValue >= beta && std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY && std::abs(alpha) < EVAL_TBWIN_IN_MAX_PLY)
-        bestValue = (bestValue * depth + beta) / (depth + 1);
+        bestValue = (bestValue * depth + 100 * beta) / (depth + 100);
 
     if (moveCount == 0) {
         if (board->checkers && excluded)
@@ -1167,7 +1167,7 @@ movesLoop:
 
     // Adjust correction history
     if (!board->checkers && (bestMove == MOVE_NONE || !board->isCapture(bestMove)) && (!failHigh || bestValue > stack->staticEval) && (!failLow || bestValue <= stack->staticEval)) {
-        int bonus = std::clamp((int)(bestValue - stack->staticEval) * depth * correctionHistoryFactor / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+        int bonus = std::clamp((int(bestValue - stack->staticEval) * depth / 100) * correctionHistoryFactor / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
         history.updateCorrectionHistory(board, stack, bonus);
     }
 
@@ -1263,7 +1263,7 @@ void Worker::iterativeDeepening() {
     }
     multiPvCount = std::min(multiPvCount, UCI::Options.multiPV.value);
 
-    int maxDepth = searchParameters.depth == 0 ? MAX_PLY - 1 : std::min(MAX_PLY - 1, searchParameters.depth);
+    int maxDepth = searchParameters.depth == 0 ? MAX_PLY - 1 : std::min<int16_t>(MAX_PLY - 1, searchParameters.depth);
 
     Eval previousValue = EVAL_NONE;
     Move previousMove = MOVE_NONE;
@@ -1280,7 +1280,7 @@ void Worker::iterativeDeepening() {
 
     rootMoveNodes.clear();
 
-    for (int depth = 1; depth <= maxDepth; depth++) {
+    for (int16_t depth = 1; depth <= maxDepth; depth++) {
         excludedRootMoves.clear();
         for (int rootMoveIdx = 0; rootMoveIdx < multiPvCount; rootMoveIdx++) {
 
@@ -1322,7 +1322,7 @@ void Worker::iterativeDeepening() {
             int failHighs = 0;
             while (true) {
                 int searchDepth = std::max(1, depth - failHighs);
-                value = search<ROOT_NODE>(board, stack, searchDepth, alpha, beta, false);
+                value = search<ROOT_NODE>(board, stack, searchDepth * 100, alpha, beta, false);
 
                 sortRootMoves();
 
@@ -1500,9 +1500,9 @@ void Worker::tdatagen() {
 
     rootMoveNodes.clear();
 
-    int maxDepth = searchParameters.depth == 0 ? MAX_PLY - 1 : std::min(MAX_PLY - 1, searchParameters.depth);
+    int maxDepth = searchParameters.depth == 0 ? MAX_PLY - 1 : std::min<int16_t>(MAX_PLY - 1, searchParameters.depth);
 
-    for (int depth = 1; depth <= maxDepth; depth++) {
+    for (int16_t depth = 1; depth <= maxDepth; depth++) {
         for (int i = 0; i < MAX_PLY + STACK_OVERHEAD + 2; i++) {
             stackList[i].pvLength = 0;
             stackList[i].ply = i - STACK_OVERHEAD;
@@ -1538,7 +1538,7 @@ void Worker::tdatagen() {
         int failHighs = 0;
         while (true) {
             int searchDepth = std::max(1, depth - failHighs);
-            value = search<ROOT_NODE>(board, stack, searchDepth, alpha, beta, false);
+            value = search<ROOT_NODE>(board, stack, searchDepth * 100, alpha, beta, false);
 
             sortRootMoves();
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,28 +63,35 @@ TUNE_INT(qsFutilityOffset, 68, 1, 125);
 TUNE_INT(qsSeeMargin, -87, -200, 50);
 
 // Pre-search pruning
-TUNE_INT_DISABLED(iirMinDepth, 400, 100, 1000);
+TUNE_INT(ttCutFailHighMargin, 100, 0, 200);
+
+TUNE_INT(iirMinDepth, 400, 100, 1000);
+TUNE_INT(iirLowTtDepthOffset, 400, 0, 800);
+TUNE_INT(iirReduction, 100, 0, 200);
 
 TUNE_INT(staticHistoryFactor, -61, -500, -1);
 TUNE_INT(staticHistoryMin, -161, -1000, -1);
 TUNE_INT(staticHistoryMax, 170, 1, 1000);
 TUNE_INT(staticHistoryTempo, 36, 1, 1000);
 
-TUNE_INT_DISABLED(rfpDepth, 800, 200, 2000);
+TUNE_INT(rfpDepth, 800, 200, 2000);
 TUNE_INT(rfpFactor, 96, 1, 250);
 
-TUNE_INT_DISABLED(razoringDepth, 400, 200, 2000);
+TUNE_INT(razoringDepth, 400, 200, 2000);
 TUNE_INT(razoringFactor, 284, 1, 1000);
 
-TUNE_INT_DISABLED(nmpRedBase, 400, 100, 800);
-TUNE_INT_DISABLED(nmpDepthDiv, 3, 1, 6);
-TUNE_INT_DISABLED(nmpMin, 400, 1, 10);
+TUNE_INT(nmpMinDepth, 300, 0, 600);
+TUNE_INT(nmpRedBase, 400, 100, 800);
+TUNE_INT(nmpDepthDiv, 300, 1, 6);
+TUNE_INT(nmpMin, 400, 1, 10);
 TUNE_INT(nmpDivisor, 174, 10, 1000);
 TUNE_INT(nmpEvalDepth, 18, 1, 100);
 TUNE_INT(nmpEvalBase, 173, 50, 300);
 
 TUNE_INT(probCutBetaOffset, 205, 1, 500);
-TUNE_INT_DISABLED(probCutDepth, 500, 100, 1000);
+TUNE_INT(probCutDepth, 500, 100, 1000);
+
+TUNE_INT(iir2Reduction, 100, 0, 200);
 
 // In-search pruning
 TUNE_INT(earlyLmrReductionTableFactor, 101, 500, 2000);
@@ -92,25 +99,28 @@ TUNE_INT(earlyLmrReductionTableFactor, 101, 500, 2000);
 TUNE_INT(earlyLmrHistoryFactorQuiet, 16009, 10000, 20000);
 TUNE_INT(earlyLmrHistoryFactorCapture, 14637, 10000, 20000);
 
-TUNE_INT_DISABLED(fpDepth, 1100, 100, 2000);
+TUNE_INT(fpDepth, 1100, 100, 2000);
 TUNE_INT(fpBase, 206, 1, 1000);
 TUNE_INT(fpFactor, 101, 1, 500);
 
-TUNE_INT_DISABLED(fpCaptDepth, 900, 100, 2000);
+TUNE_INT(fpCaptDepth, 900, 100, 2000);
 TUNE_INT(fpCaptBase, 403, 150, 750);
 TUNE_INT(fpCaptFactor, 403, 100, 600);
 
-TUNE_INT_DISABLED(historyPruningDepth, 400, 100, 1000);
+TUNE_INT(historyPruningDepth, 400, 100, 1000);
 TUNE_INT(historyPruningFactorCapture, -1879, -8192, -128);
 TUNE_INT(historyPruningFactorQuiet, -6129, -8192, -128);
 
+TUNE_INT(extensionMinDepth, 600, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 300, 0, 600);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 100, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
 TUNE_INT_DISABLED(doubleExtensionDepthIncrease, 1100, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT_DISABLED(lmrMinDepth, 300, 100, 600);
+TUNE_INT(lmrMinDepth, 300, 100, 600);
 
 TUNE_INT(lmrCheck, 88, 0, 500);
 TUNE_INT(lmrTtPv, 194, 0, 500);
@@ -121,15 +131,24 @@ TUNE_INT(lmrHistoryFactorQuiet, 25301, 10000, 30000);
 TUNE_INT(lmrHistoryFactorCapture, 3099400, 2500000, 4000000);
 
 TUNE_INT(postlmrOppWorseningThreshold, 303, 150, 450);
+TUNE_INT(postlmrOppWorseningReduction, 100, 0, 200);
 
+TUNE_INT(lmrPvNodeExtension, 100, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
+TUNE_INT(lmrDeeperWeight, 100, 0, 200);
+TUNE_INT(lmrShallowerWeight, 100, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 400, 0, 800);
 
 TUNE_INT(lmrPassBonusBase, -311, -500, 500);
 TUNE_INT(lmrPassBonusFactor, 190, 1, 500);
 TUNE_INT(lmrPassBonusMax, 1023, 32, 4096);
 
 TUNE_INT(historyDepthBetaOffset, 247, 1, 500);
+
+TUNE_INT(lowDepthPvDepthReductionMin, 400, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1000, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 100, 0, 200);
 
 TUNE_INT(correctionHistoryFactor, 163, 32, 512);
 
@@ -615,7 +634,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth - 50 + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth - 50 + ttCutFailHighMargin * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe
@@ -712,14 +731,14 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
     }
 
     // IIR
-    if ((!ttHit || ttDepth + 400 < depth) && depth >= iirMinDepth)
-        depth -= 100;
+    if ((!ttHit || ttDepth + iirLowTtDepthOffset < depth) && depth >= iirMinDepth)
+        depth -= iirReduction;
 
     // Post-LMR depth adjustments
     if ((stack - 1)->inLMR) {
         int additionalReduction = 0;
         if ((stack - 1)->reduction >= postlmrOppWorseningThreshold && stack->staticEval <= -(stack - 1)->staticEval)
-            additionalReduction -= 100;
+            additionalReduction -= postlmrOppWorseningReduction;
 
         depth -= additionalReduction;
         (stack - 1)->reduction += additionalReduction;
@@ -744,7 +763,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
         && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY
         && !excluded
         && (stack - 1)->movedPiece != Piece::NONE
-        && depth >= 300
+        && depth >= nmpMinDepth
         && stack->ply >= searchData.nmpPlies
         && board->hasNonPawns()
         ) {
@@ -753,7 +772,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
         stack->movedPiece = Piece::NONE;
         stack->contHist = history.continuationHistory[board->stm][0][0];
         stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][0][0];
-        int R = nmpRedBase + depth / nmpDepthDiv + std::min(100 * (eval - beta) / nmpDivisor, nmpMin);
+        int R = nmpRedBase + 100 * depth / nmpDepthDiv + std::min(100 * (eval - beta) / nmpDivisor, nmpMin);
 
         Board* boardCopy = doNullMove(board);
         Eval nullValue = -search<NON_PV_NODE>(boardCopy, stack + 1, depth - R, -beta, -beta + 1, !cutNode);
@@ -830,7 +849,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
 
     // IIR 2: Electric boolagoo
     if (!ttHit && depth >= iirMinDepth && pvNode)
-        depth -= 100;
+        depth -= iir2Reduction;
 
 movesLoop:
 
@@ -907,12 +926,12 @@ movesLoop:
         bool doExtensions = !rootNode && stack->ply < searchData.rootDepth * 2;
         int extension = 0;
         if (doExtensions
-            && depth >= 600
+            && depth >= extensionMinDepth
             && move == ttMove
             && !excluded
             && (ttFlag & TT_LOWERBOUND)
             && std::abs(ttValue) < EVAL_TBWIN_IN_MAX_PLY
-            && ttDepth >= depth - 300
+            && ttDepth >= depth - extensionTtDepthOffset
             ) {
             Eval singularBeta = ttValue - (1 + (stack->ttPv && !pvNode)) * depth / 100;
             int singularDepth = (depth - 1) / 2;
@@ -931,7 +950,7 @@ movesLoop:
                 extension = 1;
                 if (!pvNode && singularValue + doubleExtensionMargin < singularBeta) {
                     extension = 2;
-                    depth += 100 * (depth < doubleExtensionDepthIncrease);
+                    depth += doubleExtensionDepthIncreaseFactor * (depth < doubleExtensionDepthIncrease);
                     if (!board->isCapture(move) && singularValue + tripleExtensionMargin < singularBeta)
                         extension = 3;
                 }
@@ -1014,12 +1033,12 @@ movesLoop:
                     reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
 
-            int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100 * pvNode);
+            int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + lmrPvNodeExtension * pvNode);
             stack->reduction = reduction;
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
             stack->inLMR = false;
-            reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100 * pvNode);
+            reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + lmrPvNodeExtension * pvNode);
             stack->reduction = 0;
 
             if (capture && captureMoveCount < 32)
@@ -1029,9 +1048,9 @@ movesLoop:
 
             bool doShallowerSearch = !rootNode && value < bestValue + newDepth / 100;
             bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth / 100);
-            newDepth += 100 * doDeeperSearch - 100 * doShallowerSearch;
+            newDepth += lmrDeeperWeight * doDeeperSearch - lmrShallowerWeight * doShallowerSearch;
 
-            if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - 400 >= newDepth && (ttFlag & TT_UPPERBOUND))) {
+            if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - lmrResearchSkipDepthOffset >= newDepth && (ttFlag & TT_UPPERBOUND))) {
                 value = -search<NON_PV_NODE>(boardCopy, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);
 
                 if (capture && captureMoveCount < 32)
@@ -1135,8 +1154,8 @@ movesLoop:
                     break;
                 }
 
-                if (depth > 400 && depth < 1000 && beta < EVAL_TBWIN_IN_MAX_PLY && value > -EVAL_TBWIN_IN_MAX_PLY)
-                    depth -= 100;
+                if (depth > lowDepthPvDepthReductionMin && depth < lowDepthPvDepthReductionMax && beta < EVAL_TBWIN_IN_MAX_PLY && value > -EVAL_TBWIN_IN_MAX_PLY)
+                    depth -= lowDepthPvDepthReductionWeight;
             }
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -615,7 +615,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
     }
 
     // TT cutoff
-    if (!pvNode && ttDepth >= depth + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
+    if (!pvNode && ttDepth >= depth + 50 + 100 * (ttValue >= beta) && ttValue != EVAL_NONE && ((ttFlag == TT_UPPERBOUND && ttValue <= alpha) || (ttFlag == TT_LOWERBOUND && ttValue >= beta) || (ttFlag == TT_EXACTBOUND)))
         return ttValue;
 
     // TB Probe

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -105,7 +105,7 @@ TUNE_INT(historyPruningFactorCapture, -1879, -8192, -128);
 TUNE_INT(historyPruningFactorQuiet, -6129, -8192, -128);
 
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
-TUNE_INT_DISABLED(doubleExtensionDepthIncrease, 11, 2, 20);
+TUNE_INT_DISABLED(doubleExtensionDepthIncrease, 1100, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,8 +82,8 @@ TUNE_INT(razoringFactor, 284, 1, 1000);
 
 TUNE_INT(nmpMinDepth, 300, 0, 600);
 TUNE_INT(nmpRedBase, 400, 100, 800);
-TUNE_INT(nmpDepthDiv, 300, 1, 6);
-TUNE_INT(nmpMin, 400, 1, 10);
+TUNE_INT(nmpDepthDiv, 300, 100, 600);
+TUNE_INT(nmpMin, 400, 100, 800);
 TUNE_INT(nmpDivisor, 174, 10, 1000);
 TUNE_INT(nmpEvalDepth, 18, 1, 100);
 TUNE_INT(nmpEvalBase, 173, 50, 300);
@@ -94,7 +94,7 @@ TUNE_INT(probCutDepth, 500, 100, 1000);
 TUNE_INT(iir2Reduction, 100, 0, 200);
 
 // In-search pruning
-TUNE_INT(earlyLmrReductionTableFactor, 101, 500, 2000);
+TUNE_INT(earlyLmrReductionTableFactor, 101, 100, 200);
 
 TUNE_INT(earlyLmrHistoryFactorQuiet, 16009, 10000, 20000);
 TUNE_INT(earlyLmrHistoryFactorCapture, 14637, 10000, 20000);
@@ -934,7 +934,7 @@ movesLoop:
             && ttDepth >= depth - extensionTtDepthOffset
             ) {
             Eval singularBeta = ttValue - (1 + (stack->ttPv && !pvNode)) * depth / 100;
-            int singularDepth = (depth - 1) / 2;
+            int singularDepth = (depth - 100) / 2;
 
             bool currTtPv = stack->ttPv;
             stack->excludedMove = move;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -39,120 +39,120 @@ TUNE_FLOAT_DISABLED(tmNodesFactor, 0.9741686475516691f, 0.1f, 2.5f);
 TUNE_INT_DISABLED(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT_DISABLED(aspirationWindowDelta, 14, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowDeltaBase, 10, 1, 30);
-TUNE_INT(aspirationWindowDeltaDivisor, 12867, 7500, 17500);
+TUNE_INT(aspirationWindowDeltaDivisor, 12746, 7500, 17500);
 TUNE_INT_DISABLED(aspirationWindowMaxFailHighs, 3, 1, 10);
 TUNE_FLOAT_DISABLED(aspirationWindowDeltaFactor, 1.5804938062670641f, 1.0f, 3.0f);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.1469526773526456f, -2.0f, -0.1f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.2913929348541524f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 1.1249164313513371f, 0.50f, 1.5f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.9803357858847743f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.14053578048643614f, -2.0f, -0.1f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 3.2993722858563084f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 1.138140091239296f, 0.50f, 1.5f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.953981357948658f, 2.0f, 4.0f);
 
-TUNE_FLOAT(seeMarginNoisy, -21.896447313366288f, -50.0f, -10.0f);
-TUNE_FLOAT(seeMarginQuiet, -76.08383333556118f, -100.0f, -50.0f);
-TUNE_FLOAT(lmpMarginWorseningBase, 1.8740227708454298f, -1.0f, 2.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.47626879982753145f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.588444328682528f, 1.0f, 3.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 2.5759702639663975f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 0.867434947078185f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 1.9225038758479083f, 1.0f, 3.0f);
+TUNE_FLOAT(seeMarginNoisy, -22.239841698994745f, -50.0f, -10.0f);
+TUNE_FLOAT(seeMarginQuiet, -76.69216909301984f, -100.0f, -50.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.9195713820319065f, -1.0f, 2.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.42766333890804775f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.6061173081545654f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 2.6926099313604643f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 0.857988703638067f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 1.9576685646611904f, 1.0f, 3.0f);
 
 // Search values
-TUNE_INT(qsFutilityOffset, 68, 1, 125);
-TUNE_INT(qsSeeMargin, -82, -200, 50);
+TUNE_INT(qsFutilityOffset, 70, 1, 125);
+TUNE_INT(qsSeeMargin, -90, -200, 50);
 
 // Pre-search pruning
-TUNE_INT(ttCutOffset, 50, -100, 200);
-TUNE_INT(ttCutFailHighMargin, 100, 0, 200);
+TUNE_INT(ttCutOffset, 51, -100, 200);
+TUNE_INT(ttCutFailHighMargin, 99, 0, 200);
 
-TUNE_INT(iirMinDepth, 379, 100, 1000);
-TUNE_INT(iirLowTtDepthOffset, 414, 0, 800);
-TUNE_INT(iirReduction, 95, 0, 200);
+TUNE_INT(iirMinDepth, 349, 100, 1000);
+TUNE_INT(iirLowTtDepthOffset, 429, 0, 800);
+TUNE_INT(iirReduction, 88, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -65, -500, -1);
-TUNE_INT(staticHistoryMin, -179, -1000, -1);
-TUNE_INT(staticHistoryMax, 164, 1, 1000);
-TUNE_INT(staticHistoryTempo, 26, 1, 100);
+TUNE_INT(staticHistoryFactor, -88, -500, -1);
+TUNE_INT(staticHistoryMin, -143, -1000, -1);
+TUNE_INT(staticHistoryMax, 210, 1, 1000);
+TUNE_INT(staticHistoryTempo, 28, 1, 200);
 
-TUNE_INT(rfpDepth, 843, 200, 2000);
-TUNE_INT(rfpFactor, 88, 1, 250);
+TUNE_INT(rfpDepth, 837, 200, 2000);
+TUNE_INT(rfpFactor, 80, 1, 250);
 
-TUNE_INT(razoringDepth, 421, 200, 2000);
-TUNE_INT(razoringFactor, 285, 1, 1000);
+TUNE_INT(razoringDepth, 474, 200, 2000);
+TUNE_INT(razoringFactor, 277, 1, 1000);
 
-TUNE_INT(nmpMinDepth, 323, 0, 600);
-TUNE_INT(nmpRedBase, 398, 100, 800);
-TUNE_INT(nmpDepthDiv, 308, 100, 600);
-TUNE_INT(nmpMin, 400, 100, 800);
-TUNE_INT(nmpDivisor, 199, 10, 600);
-TUNE_INT(nmpEvalDepth, 14, 1, 100);
-TUNE_INT(nmpEvalBase, 173, 50, 300);
+TUNE_INT(nmpMinDepth, 317, 0, 600);
+TUNE_INT(nmpRedBase, 401, 100, 800);
+TUNE_INT(nmpDepthDiv, 298, 100, 600);
+TUNE_INT(nmpMin, 374, 100, 800);
+TUNE_INT(nmpDivisor, 234, 10, 600);
+TUNE_INT(nmpEvalDepth, 9, 1, 100);
+TUNE_INT(nmpEvalBase, 161, 50, 300);
 
-TUNE_INT(probcutReduction, 300, 0, 600);
-TUNE_INT(probCutBetaOffset, 207, 1, 500);
-TUNE_INT(probCutDepth, 481, 100, 1000);
+TUNE_INT(probcutReduction, 324, 0, 600);
+TUNE_INT(probCutBetaOffset, 197, 1, 500);
+TUNE_INT(probCutDepth, 496, 100, 1000);
 
-TUNE_INT(iir2Reduction, 101, 0, 200);
+TUNE_INT(iir2Reduction, 108, 0, 200);
 
 // In-search pruning
-TUNE_INT(earlyLmrImproving, 100, 1, 500);
+TUNE_INT(earlyLmrImproving, 110, 1, 500);
 
-TUNE_INT(earlyLmrHistoryFactorQuiet, 16131, 10000, 20000);
-TUNE_INT(earlyLmrHistoryFactorCapture, 14641, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorQuiet, 16229, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorCapture, 14912, 10000, 20000);
 
-TUNE_INT(fpDepth, 1129, 100, 2000);
-TUNE_INT(fpBase, 251, 1, 1000);
-TUNE_INT(fpFactor, 103, 1, 500);
+TUNE_INT(fpDepth, 1149, 100, 2000);
+TUNE_INT(fpBase, 234, 1, 1000);
+TUNE_INT(fpFactor, 101, 1, 500);
 
-TUNE_INT(fpCaptDepth, 911, 100, 2000);
-TUNE_INT(fpCaptBase, 419, 150, 750);
-TUNE_INT(fpCaptFactor, 416, 100, 600);
+TUNE_INT(fpCaptDepth, 1005, 100, 2000);
+TUNE_INT(fpCaptBase, 418, 150, 750);
+TUNE_INT(fpCaptFactor, 422, 100, 600);
 
-TUNE_INT(historyPruningDepth, 435, 100, 1000);
-TUNE_INT(historyPruningFactorCapture, -1723, -8192, -128);
-TUNE_INT(historyPruningFactorQuiet, -6292, -8192, -128);
+TUNE_INT(historyPruningDepth, 439, 100, 1000);
+TUNE_INT(historyPruningFactorCapture, -1993, -8192, -128);
+TUNE_INT(historyPruningFactorQuiet, -6332, -8192, -128);
 
-TUNE_INT(extensionMinDepth, 629, 0, 1200);
-TUNE_INT(extensionTtDepthOffset, 350, 0, 600);
-TUNE_INT(doubleExtensionDepthIncreaseFactor, 96, 0, 200);
+TUNE_INT(extensionMinDepth, 653, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 402, 0, 600);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 88, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
-TUNE_INT(doubleExtensionDepthIncrease, 1100, 200, 2000);
+TUNE_INT(doubleExtensionDepthIncrease, 1152, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT(lmrMinDepth, 291, 100, 600);
+TUNE_INT(lmrMinDepth, 296, 100, 600);
 
-TUNE_INT(lmrCheck, 81, 0, 500);
-TUNE_INT(lmrTtPv, 192, 0, 500);
-TUNE_INT(lmrCutnode, 206, 0, 500);
-TUNE_INT(lmrTtpvFaillow, 84, 0, 500);
-TUNE_INT(lmrCorrection, 145323, 10000, 200000);
-TUNE_INT(lmrHistoryFactorQuiet, 26936, 10000, 30000);
-TUNE_INT(lmrHistoryFactorCapture, 3068010, 2500000, 4000000);
+TUNE_INT(lmrCheck, 82, 0, 500);
+TUNE_INT(lmrTtPv, 189, 0, 500);
+TUNE_INT(lmrCutnode, 222, 0, 500);
+TUNE_INT(lmrTtpvFaillow, 81, 0, 500);
+TUNE_INT(lmrCorrection, 143222, 10000, 200000);
+TUNE_INT(lmrHistoryFactorQuiet, 27246, 10000, 30000);
+TUNE_INT(lmrHistoryFactorCapture, 3031309, 2500000, 4000000);
 
-TUNE_INT(postlmrOppWorseningThreshold, 310, 150, 450);
-TUNE_INT(postlmrOppWorseningReduction, 112, 0, 200);
+TUNE_INT(postlmrOppWorseningThreshold, 293, 150, 450);
+TUNE_INT(postlmrOppWorseningReduction, 121, 0, 200);
 
-TUNE_INT(lmrPvNodeExtension, 104, 0, 200);
+TUNE_INT(lmrPvNodeExtension, 101, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
-TUNE_INT(lmrDeeperWeight, 107, 0, 200);
-TUNE_INT(lmrShallowerWeight, 102, 0, 200);
-TUNE_INT(lmrResearchSkipDepthOffset, 396, 0, 800);
+TUNE_INT(lmrDeeperWeight, 114, 0, 200);
+TUNE_INT(lmrShallowerWeight, 107, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 387, 0, 800);
 
-TUNE_INT(lmrPassBonusBase, -310, -500, 500);
-TUNE_INT(lmrPassBonusFactor, 177, 1, 500);
-TUNE_INT(lmrPassBonusMax, 1025, 32, 4096);
+TUNE_INT(lmrPassBonusBase, -312, -500, 500);
+TUNE_INT(lmrPassBonusFactor, 180, 1, 500);
+TUNE_INT(lmrPassBonusMax, 1078, 32, 4096);
 
-TUNE_INT(historyDepthBetaOffset, 248, 1, 500);
+TUNE_INT(historyDepthBetaOffset, 250, 1, 500);
 
-TUNE_INT(lowDepthPvDepthReductionMin, 403, 0, 800);
-TUNE_INT(lowDepthPvDepthReductionMax, 1008, 0, 2000);
-TUNE_INT(lowDepthPvDepthReductionWeight, 99, 0, 200);
+TUNE_INT(lowDepthPvDepthReductionMin, 411, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1006, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 98, 0, 200);
 
-TUNE_INT(correctionHistoryFactor, 169, 32, 512);
+TUNE_INT(correctionHistoryFactor, 172, 32, 512);
 
 int REDUCTIONS[2][MAX_PLY][MAX_MOVES];
 int SEE_MARGIN[MAX_PLY][2];

--- a/src/search.h
+++ b/src/search.h
@@ -17,7 +17,7 @@ extern int LMP_MARGIN[MAX_PLY][2];
 
 void initReductions();
 
-uint64_t perft(Board& board, int depth);
+uint64_t perft(Board& board, int16_t depth);
 
 struct SearchParameters {
     bool perft; // Perft (requires depth)
@@ -32,7 +32,7 @@ struct SearchParameters {
     uint64_t winc; // White's increment per move (ms)
     uint64_t binc; // Black's increment per move (ms)
     int movestogo; // Moves to the next time control
-    int depth; // Search depth
+    int16_t depth; // Search depth
     uint64_t nodes; // Search exactly this many nodes
     int mate; // TODO: Search for mate in X moves
     uint64_t movetime; // Search exactly this many ms

--- a/src/spsa.h
+++ b/src/spsa.h
@@ -92,7 +92,7 @@ public:
 
 };
 
-#define TUNE_ENABLED false
+#define TUNE_ENABLED true
 
 // Some fancy macro stuff to call the tune() methods inline from anywhere
 #define STRINGIFY(x) #x

--- a/src/spsa.h
+++ b/src/spsa.h
@@ -92,7 +92,7 @@ public:
 
 };
 
-#define TUNE_ENABLED true
+#define TUNE_ENABLED false
 
 // Some fancy macro stuff to call the tune() methods inline from anywhere
 #define STRINGIFY(x) #x

--- a/src/thread.h
+++ b/src/thread.h
@@ -17,7 +17,7 @@
 struct RootMove {
     Eval value = -EVAL_INFINITE;
     Eval meanScore = EVAL_NONE;
-    int depth = 0;
+    int16_t depth = 0;
     int selDepth = 0;
     Move move = MOVE_NULL;
     std::vector<Move> pv;
@@ -83,7 +83,7 @@ private:
     bool isDraw(Board* board, int ply);
 
     template <NodeType nt>
-    Eval search(Board* board, SearchStack* stack, int depth, Eval alpha, Eval beta, bool cutNode);
+    Eval search(Board* board, SearchStack* stack, int16_t depth, Eval alpha, Eval beta, bool cutNode);
 
     template <NodeType nodeType>
     Eval qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -2,10 +2,10 @@
 #include "move.h"
 #include "spsa.h"
 
-TUNE_INT(ttReplaceTtpvBonus, 200, 0, 400);
-TUNE_INT(ttReplaceOffset, 400, 0, 800);
-TUNE_INT(ttDepthAgingMinDepth, 500, 0, 1000);
-TUNE_INT(ttDepthAgingReduction, 100, 0, 200);
+TUNE_INT(ttReplaceTtpvBonus, 209, 0, 400);
+TUNE_INT(ttReplaceOffset, 415, 0, 800);
+TUNE_INT(ttDepthAgingMinDepth, 488, 0, 1000);
+TUNE_INT(ttDepthAgingReduction, 94, 0, 200);
 
 void TTEntry::update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, bool wasPv, int _flags) {
     // Update bestMove if not MOVE_NONE

--- a/src/tt.h
+++ b/src/tt.h
@@ -46,7 +46,7 @@ constexpr uint8_t TT_UPPERBOUND = 1;
 constexpr uint8_t TT_LOWERBOUND = 2;
 constexpr uint8_t TT_EXACTBOUND = 3;
 
-constexpr int CLUSTER_SIZE = 3;
+constexpr int CLUSTER_SIZE = 5;
 
 constexpr int GENERATION_PADDING = 3; // Reserved bits for flag / ttPv
 constexpr int GENERATION_DELTA = (1 << GENERATION_PADDING);
@@ -58,28 +58,28 @@ extern uint8_t TT_GENERATION_COUNTER;
 struct TTEntry {
     uint16_t hash = 0;
     Move bestMove = 0;
-    uint8_t depth = 0;
+    int16_t depth = 0;
     uint8_t flags = 0;
     int16_t eval = 0;
     int16_t value = 0;
 
     constexpr Move getMove() { return bestMove; };
-    constexpr int getDepth() { return depth; };
+    constexpr int16_t getDepth() { return depth; };
     constexpr uint8_t getFlag() { return flags & 0x3; };
     constexpr Eval getEval() { return eval; };
     constexpr Eval getValue() { return value; };
     constexpr bool getTtPv() { return flags & 0x4; };
 
-    void update(uint64_t _hash, Move _bestMove, uint8_t _depth, Eval _eval, Eval _value, bool wasPv, int _flags);
+    void update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, bool wasPv, int _flags);
     bool isInitialised() { return hash != 0; };
 };
 
 struct TTCluster {
     TTEntry entries[CLUSTER_SIZE];
-    char padding[2];
+    char padding[4];
 };
 
-static_assert(sizeof(TTCluster) == 32, "TTCluster size not correct!");
+static_assert(sizeof(TTCluster) == 64, "TTCluster size not correct!");
 
 class TranspositionTable {
 

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 constexpr int MAX_PLY = 246;
+constexpr int16_t MAX_DEPTH = (MAX_PLY - 1) * 100;
 constexpr int MAX_MOVES = 218;
 constexpr int MAX_CAPTURES = 74;
 
@@ -96,7 +97,7 @@ struct SearchStack {
     Piece movedPiece;
     bool inCheck, capture;
     int correctionValue;
-    int reduction;
+    int16_t reduction;
     bool inLMR, ttPv;
 
     Move excludedMove;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.12";
+constexpr auto VERSION = "6.0.13";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | -2.05 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 2.50]
Games | N: 20472 W: 4876 L: 4997 D: 10599
Penta | [58, 2451, 5320, 2368, 39]
https://furybench.com/test/1883/
```
VLTC
```
Elo   | 3.25 +- 2.02 (95%)
SPRT  | 80.0+0.80s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 24170 W: 5960 L: 5734 D: 12476
Penta | [6, 2432, 6979, 2666, 2]
https://furybench.com/test/1875/
```
SMP Verification
```
Elo   | 2.81 +- 2.19 (95%)
SPRT  | 12.0+0.12s Threads=8 Hash=128MB
LLR   | 2.06 (-2.25, 2.89) [0.00, 2.50]
Games | N: 20526 W: 5104 L: 4938 D: 10484
Penta | [3, 2087, 5917, 2253, 3]
https://furybench.com/test/1884/
```

Bench: 1546066