### PR TITLE
Modify LMR pv-node extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1035,12 +1035,12 @@ movesLoop:
                     reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
 
-            int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + lmrPvNodeExtension * pvNode);
+            int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;
             stack->reduction = reduction;
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
             stack->inLMR = false;
-            reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + lmrPvNodeExtension * pvNode);
+            reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;
             stack->reduction = 0;
 
             if (capture && captureMoveCount < 32)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.13";
+constexpr auto VERSION = "6.0.14";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.15 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 46842 W: 11530 L: 11240 D: 24072
Penta | [104, 5426, 12079, 5700, 112]
https://furybench.com/test/1906/
```
LTC
```
Elo   | 2.42 +- 1.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 36950 W: 9071 L: 8814 D: 19065
Penta | [13, 4051, 10100, 4288, 23]
https://furybench.com/test/1909/
```

Bench: 1904372