### PR TITLE
Remove negative extensions in case of low ttValue

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -969,8 +969,6 @@ movesLoop:
             // We didn't prove singularity and an excluded search couldn't beat beta, but we are expected to fail low, so reduce
             else if (cutNode)
                 extension = -2;
-            else if (ttValue <= alpha)
-                extension = -1;
         }
 
         uint64_t newHash = board->hashAfter(move);

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.15";
+constexpr auto VERSION = "6.0.16";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.64 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 70486 W: 17311 L: 16979 D: 36196
Penta | [156, 8158, 18312, 8432, 185]
https://furybench.com/test/2120/
```
LTC
```
Elo   | 2.38 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 36730 W: 8882 L: 8630 D: 19218
Penta | [16, 3899, 10286, 4145, 19]
https://furybench.com/test/2141/
```

Bench: 2027547