### PR TITLE
Apply fifty-move-rule scaling after extracting static eval from the TT

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -44,7 +44,6 @@ Eval evaluate(Board* board, NNUE* nnue) {
 
     Eval eval = nnue->evaluate(board);
     eval = (eval * getMaterialScale(board)) / 1024;
-    eval = eval * (300 - board->rule50_ply) / 300;
 
     eval = std::clamp((int)eval, (int)-EVAL_TBWIN_IN_MAX_PLY + 1, (int)EVAL_TBWIN_IN_MAX_PLY - 1);
     return (eval / 16) * 16;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -81,7 +81,8 @@ Eval History::getCorrectionValue(Board* board, SearchStack* searchStack) {
     return pawnEntry * pawnCorrectionFactor + nonPawnEntry * nonPawnCorrectionFactor + minorEntry * minorCorrectionFactor + majorEntry * majorCorrectionFactor + contEntry * continuationCorrectionFactor;
 }
 
-Eval History::correctStaticEval(Eval eval, Eval correctionValue) {
+Eval History::correctStaticEval(uint8_t rule50, Eval eval, Eval correctionValue) {
+    eval = eval * (300 - rule50) / 300;
     Eval adjustedEval = eval + correctionValue / 65536;
     adjustedEval = std::clamp((int)adjustedEval, (int)-EVAL_TBWIN_IN_MAX_PLY + 1, (int)EVAL_TBWIN_IN_MAX_PLY - 1);
     return adjustedEval;

--- a/src/history.h
+++ b/src/history.h
@@ -28,7 +28,7 @@ public:
     void initHistory();
 
     Eval getCorrectionValue(Board* board, SearchStack* searchStack);
-    Eval correctStaticEval(Eval eval, Eval correctionValue);
+    Eval correctStaticEval(uint8_t rule50, Eval eval, Eval correctionValue);
     void updateCorrectionHistory(Board* board, SearchStack* searchStack, int16_t bonus);
 
     int getHistory(Board* board, SearchStack* searchStack, Move move, bool isCapture);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -7,7 +7,7 @@ TUNE_INT(ttReplaceOffset, 415, 0, 800);
 TUNE_INT(ttDepthAgingMinDepth, 488, 0, 1000);
 TUNE_INT(ttDepthAgingReduction, 94, 0, 200);
 
-void TTEntry::update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, bool wasPv, int _flags) {
+void TTEntry::update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, uint8_t _rule50, bool wasPv, int _flags) {
     // Update bestMove if not MOVE_NONE
     // Or even clear move for a different position
     if (_bestMove != MOVE_NONE || (uint16_t)_hash != hash)
@@ -18,6 +18,7 @@ void TTEntry::update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval,
         depth = _depth;
         value = _value;
         eval = _eval;
+        rule50 = _rule50;
         flags = (uint8_t)(_flags + (wasPv << 2)) | TT_GENERATION_COUNTER;
     }
     else if (depth >= ttDepthAgingMinDepth && flags != TT_EXACTBOUND)

--- a/src/tt.h
+++ b/src/tt.h
@@ -59,18 +59,20 @@ struct TTEntry {
     uint16_t hash = 0;
     Move bestMove = 0;
     int16_t depth = 0;
-    uint8_t flags = 0;
     int16_t eval = 0;
     int16_t value = 0;
+    uint8_t flags = 0;
+    uint8_t rule50 = 0;
 
     constexpr Move getMove() { return bestMove; };
     constexpr int16_t getDepth() { return depth; };
     constexpr uint8_t getFlag() { return flags & 0x3; };
+    constexpr uint8_t getRule50() { return rule50; };
     constexpr Eval getEval() { return eval; };
     constexpr Eval getValue() { return value; };
     constexpr bool getTtPv() { return flags & 0x4; };
 
-    void update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, bool wasPv, int _flags);
+    void update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, uint8_t rule50, bool wasPv, int _flags);
     bool isInitialised() { return hash != 0; };
 };
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.18";
+constexpr auto VERSION = "6.0.19";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 0.84 +- 1.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.66 (-2.25, 2.89) [0.00, 2.50]
Games | N: 74576 W: 18172 L: 17991 D: 38413
Penta | [169, 8664, 19459, 8809, 187]
https://furybench.com/test/2343/
```
LTC Non-regression
```
Elo   | 7.69 +- 4.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 5104 W: 1276 L: 1163 D: 2665
Penta | [5, 505, 1417, 622, 3]
https://furybench.com/test/2357/
```

Bench: 1692864