### PR TITLE
Update corrhist in multicut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -961,6 +961,13 @@ movesLoop:
             else if (singularBeta >= beta) {
                 Eval value = std::min(singularBeta, EVAL_TBWIN_IN_MAX_PLY - 1);
                 ttEntry->update(board->hashes.hash, ttMove, singularDepth, unadjustedEval, value, board->rule50_ply, stack->ttPv, TT_LOWERBOUND);
+
+                // Adjust correction history
+                if (!board->checkers && value > stack->staticEval) {
+                    int bonus = std::clamp((int(value - stack->staticEval) * singularDepth / 100) * correctionHistoryFactor / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                    history.updateCorrectionHistory(board, stack, bonus);
+                }
+
                 return value;
             }
             // We didn't prove singularity and an excluded search couldn't beat beta, but if the ttValue can we still reduce the depth

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.20";
+constexpr auto VERSION = "6.0.21";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.88 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 31376 W: 7788 L: 7528 D: 16060
Penta | [72, 3559, 8167, 3817, 73]
https://furybench.com/test/2693/
```
LTC
```
Elo   | 1.71 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.19 (-2.25, 2.89) [0.00, 2.50]
Games | N: 44482 W: 10883 L: 10664 D: 22935
Penta | [9, 4796, 12421, 4997, 18]
https://furybench.com/test/2696/
```

Bench: 2099576