### PR TITLE
Do LMR in all node and move types

### DIFF
--- a/src/move.h
+++ b/src/move.h
@@ -59,6 +59,8 @@ constexpr MoveGenStage STAGE_DONE = 100;
 
 class MoveGen {
 
+public:
+
     Board* board;
     History* history;
     SearchStack* searchStack;
@@ -80,8 +82,6 @@ class MoveGen {
 
     bool probCut;
     int probCutThreshold;
-
-public:
 
     bool skipQuiets;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1033,8 +1033,11 @@ movesLoop:
             if (capture) {
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
 
-                if (stack->ttPv && (allNode || pvNode))
+                if (stack->ttPv && (allNode || pvNode)) {
+                    reduction -= 100;
+                    reduction += 100 * (movegen.stage == STAGE_PLAY_BAD_CAPTURES);
                     reduction /= 2;
+                }
             }
             else {
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -258,22 +258,22 @@ int valueFromTt(int value, int ply, int rule50) {
         // Downgrade potentially false mate score
         if (value >= EVAL_MATE_IN_MAX_PLY && EVAL_MATE - value > 100 - rule50)
             return EVAL_TBWIN_IN_MAX_PLY - 1;
-        
+
         // Downgrade potentially false TB score
         if (EVAL_TBWIN - value > 100 - rule50)
             return EVAL_TBWIN_IN_MAX_PLY - 1;
-        
+
         return value - ply;
     }
     else if (value <= -EVAL_TBWIN_IN_MAX_PLY) {
         // Downgrade potentially false mate score
         if (value <= -EVAL_MATE_IN_MAX_PLY && EVAL_MATE + value > 100 - rule50)
             return -EVAL_TBWIN_IN_MAX_PLY + 1;
-        
+
         // Downgrade potentially false TB score
         if (EVAL_TBWIN + value > 100 - rule50)
             return -EVAL_TBWIN_IN_MAX_PLY + 1;
-        
+
         return value + ply;
     }
     return value;
@@ -1017,30 +1017,29 @@ movesLoop:
         // Check if the move can exceed alpha
         if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth) {
             int16_t reduction = REDUCTIONS[!capture][depth / 100][moveCount];
-            
-            if (stack->ttPv && !pvNode && !cutNode && capture) {
-                // Do very slight LMR for captures in ttPv-allnodes
-                reduction /= 2;
-            } else {
-                if (boardCopy->checkers)
-                    reduction -= lmrCheck;
 
-                if (!stack->ttPv)
-                    reduction += lmrTtPv;
 
-                if (cutNode)
-                    reduction += lmrCutnode;
+            if (boardCopy->checkers)
+                reduction -= lmrCheck;
 
-                if (stack->ttPv && ttHit && ttValue <= alpha)
-                    reduction += lmrTtpvFaillow;
+            if (!stack->ttPv)
+                reduction += lmrTtPv;
 
-                reduction -= std::abs(correctionValue / lmrCorrection);
+            if (cutNode)
+                reduction += lmrCutnode;
 
-                if (capture)
-                    reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
-                else
-                    reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
-            }
+            if (stack->ttPv && ttHit && ttValue <= alpha)
+                reduction += lmrTtpvFaillow;
+
+            reduction -= std::abs(correctionValue / lmrCorrection);
+
+            if (capture)
+                reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
+            else
+                reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
+
+            if (stack->ttPv && !pvNode && !cutNode && capture)
+                reduction -= 300;
 
             if (capture && pvNode)
                 reduction -= 400;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1026,7 +1026,7 @@ movesLoop:
                 reduction += lmrCutnode;
 
             if (stack->ttPv)
-                reduction -= lmrTtPv - lmrTtpvFaillow * (ttHit && ttValue <= alpha);
+                reduction -= lmrTtPv - lmrTtpvFaillow * (ttHit && ttValue <= alpha) + 100 * cutNode;
 
             if (capture) {
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1015,9 +1015,9 @@ movesLoop:
 
         // Very basic LMR: Late moves are being searched with less depth
         // Check if the move can exceed alpha
-        if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth && (!capture || !pvNode)) {
+        if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth) {
             int16_t reduction = REDUCTIONS[!capture][depth / 100][moveCount];
-
+            
             if (stack->ttPv && !pvNode && !cutNode && capture) {
                 // Do very slight LMR for captures in ttPv-allnodes
                 reduction /= 2;
@@ -1041,6 +1041,9 @@ movesLoop:
                 else
                     reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
+
+            if (capture && pvNode)
+                reduction -= 400;
 
             int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;
             stack->reduction = reduction;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1019,6 +1019,8 @@ movesLoop:
         if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth) {
             int16_t reduction = REDUCTIONS[!capture][depth / 100][moveCount] + 189;
 
+            reduction -= std::abs(correctionValue / lmrCorrection);
+
             if (boardCopy->checkers)
                 reduction -= lmrCheck;
 
@@ -1031,16 +1033,35 @@ movesLoop:
             if (capture) {
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
 
-                if (stack->ttPv)
-                    reduction -= 400 * allNode + 400 * pvNode;
+                if (stack->ttPv && (allNode || pvNode)) {
+                    reduction /= 2;
+                    // reduction -= 100 * allNode + 100 * pvNode;
+
+                    // reduction = std::clamp(reduction / 2, -50, 150);
+
+                    if (pvNode) {
+                        Debug::average("pv red", reduction);
+                        Debug::extreme("pv red", reduction);
+                    }
+                    else {
+                        Debug::average("an red", reduction);
+                        Debug::extreme("an red", reduction);
+                    }
+                }
             }
             else {
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
 
-            reduction -= std::abs(correctionValue / lmrCorrection);
-
             int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;
+            if (capture && ((stack->ttPv && allNode) || pvNode))
+                Debug::hitrate("lower depth", reducedDepth < newDepth);
+            else {
+                Debug::hitrate("else lower depth", reducedDepth < newDepth);
+                Debug::average("else red", reduction);
+                Debug::extreme("else red", reduction);
+            }
+
             stack->reduction = reduction;
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
@@ -1056,6 +1077,12 @@ movesLoop:
             bool doShallowerSearch = !rootNode && value < bestValue + newDepth / 100;
             bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth / 100);
             newDepth += lmrDeeperWeight * doDeeperSearch - lmrShallowerWeight * doShallowerSearch;
+
+            if (capture && ((stack->ttPv && allNode) || pvNode))
+                Debug::hitrate("lower depth 2", reducedDepth < newDepth);
+
+            if (capture && ((stack->ttPv && allNode) || pvNode) && value > alpha)
+                Debug::hitrate("research", reducedDepth < newDepth && !(ttValue < alpha && ttDepth - lmrResearchSkipDepthOffset >= newDepth && (ttFlag & TT_UPPERBOUND)));
 
             if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - lmrResearchSkipDepthOffset >= newDepth && (ttFlag & TT_UPPERBOUND))) {
                 value = -search<NON_PV_NODE>(boardCopy, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1032,7 +1032,7 @@ movesLoop:
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
 
                 if (stack->ttPv)
-                    reduction -= 400 * allNode + 400 * pvNode;
+                    reduction -= 400 * allNode + 400 * pvNode - 100 * board->isCapture(ttMove);
             }
             else {
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1026,13 +1026,13 @@ movesLoop:
                 reduction += lmrCutnode;
 
             if (stack->ttPv)
-                reduction -= lmrTtPv - lmrTtpvFaillow * (ttHit && ttValue <= alpha) + 100 * cutNode;
+                reduction -= lmrTtPv - lmrTtpvFaillow * (ttHit && ttValue <= alpha);
 
             if (capture) {
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
 
                 if (stack->ttPv)
-                    reduction -= 400 * allNode + 400 * pvNode - 100 * board->isCapture(ttMove);
+                    reduction -= 400 * allNode + 400 * pvNode;
             }
             else {
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1033,35 +1033,14 @@ movesLoop:
             if (capture) {
                 reduction -= moveHistory * std::abs(moveHistory) / lmrHistoryFactorCapture;
 
-                if (stack->ttPv && (allNode || pvNode)) {
+                if (stack->ttPv && (allNode || pvNode))
                     reduction /= 2;
-                    // reduction -= 100 * allNode + 100 * pvNode;
-
-                    // reduction = std::clamp(reduction / 2, -50, 150);
-
-                    if (pvNode) {
-                        Debug::average("pv red", reduction);
-                        Debug::extreme("pv red", reduction);
-                    }
-                    else {
-                        Debug::average("an red", reduction);
-                        Debug::extreme("an red", reduction);
-                    }
-                }
             }
             else {
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
             }
 
             int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;
-            if (capture && ((stack->ttPv && allNode) || pvNode))
-                Debug::hitrate("lower depth", reducedDepth < newDepth);
-            else {
-                Debug::hitrate("else lower depth", reducedDepth < newDepth);
-                Debug::average("else red", reduction);
-                Debug::extreme("else red", reduction);
-            }
-
             stack->reduction = reduction;
             stack->inLMR = true;
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, reducedDepth, -(alpha + 1), -alpha, true);
@@ -1077,12 +1056,6 @@ movesLoop:
             bool doShallowerSearch = !rootNode && value < bestValue + newDepth / 100;
             bool doDeeperSearch = value > (bestValue + lmrDeeperBase + lmrDeeperFactor * newDepth / 100);
             newDepth += lmrDeeperWeight * doDeeperSearch - lmrShallowerWeight * doShallowerSearch;
-
-            if (capture && ((stack->ttPv && allNode) || pvNode))
-                Debug::hitrate("lower depth 2", reducedDepth < newDepth);
-
-            if (capture && ((stack->ttPv && allNode) || pvNode) && value > alpha)
-                Debug::hitrate("research", reducedDepth < newDepth && !(ttValue < alpha && ttDepth - lmrResearchSkipDepthOffset >= newDepth && (ttFlag & TT_UPPERBOUND)));
 
             if (value > alpha && reducedDepth < newDepth && !(ttValue < alpha && ttDepth - lmrResearchSkipDepthOffset >= newDepth && (ttFlag & TT_UPPERBOUND))) {
                 value = -search<NON_PV_NODE>(boardCopy, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1018,7 +1018,6 @@ movesLoop:
         if (moveCount > lmrMcBase + lmrMcPv * rootNode - (ttMove != MOVE_NONE) && depth >= lmrMinDepth) {
             int16_t reduction = REDUCTIONS[!capture][depth / 100][moveCount];
 
-
             if (boardCopy->checkers)
                 reduction -= lmrCheck;
 
@@ -1039,7 +1038,7 @@ movesLoop:
                 reduction -= 100 * moveHistory / lmrHistoryFactorQuiet;
 
             if (stack->ttPv && !pvNode && !cutNode && capture)
-                reduction -= 300;
+                reduction -= 400;
 
             if (capture && pvNode)
                 reduction -= 400;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.22";
+constexpr auto VERSION = "6.0.23";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.91 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 30470 W: 7504 L: 7249 D: 15717
Penta | [60, 3389, 8091, 3626, 69]
https://furybench.com/test/2768/
```
LTC
```
Elo   | 1.19 +- 1.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.29 (-2.25, 2.89) [0.00, 2.50]
Games | N: 88670 W: 21718 L: 21415 D: 45537
Penta | [42, 9692, 24574, 9975, 52]
https://furybench.com/test/2770/
```

Bench: 1785198