### PR TITLE
Do fail medium in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,6 +579,10 @@ movesLoopQsearch:
         bestValue = matedIn(stack->ply); // Checkmate
     }
 
+    if (!pvNode && std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY && bestValue >= beta) {
+        bestValue = (bestValue + beta) / 2;
+    }
+
     // Insert into TT
     int flags = bestValue >= beta ? TT_LOWERBOUND : TT_UPPERBOUND;
     ttEntry->update(board->hashes.hash, bestMove, 0, unadjustedEval, valueToTT(bestValue, stack->ply), board->rule50_ply, ttPv, flags);

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "6.0.25";
+constexpr auto VERSION = "6.0.26";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 6.73 +- 3.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 11508 W: 2896 L: 2673 D: 5939
Penta | [21, 1219, 3056, 1432, 26]
https://furybench.com/test/2921/
```
LTC
```
Elo   | 3.88 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 20040 W: 4889 L: 4665 D: 10486
Penta | [6, 2097, 5591, 2319, 7]
https://furybench.com/test/2923/
```

Bench: 1691935