### PR TITLE
Sometimes prevent qsearch drop for ttmoves in non-pv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1111,6 +1111,9 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
             }
         }
         else if (!pvNode || moveCount > 1) {
+            if (move == ttMove && searchData.rootDepth > 8 && ttDepth > 1)
+                newDepth = std::max(100, newDepth);
+
             value = -search<NON_PV_NODE>(boardCopy, stack + 1, newDepth, -(alpha + 1), -alpha, !cutNode);
 
             if (capture && captureMoveCount < 32)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.2";
+constexpr auto VERSION = "7.0.3";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | -0.47 +- 1.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 2.50]
Games | N: 50052 W: 12098 L: 12166 D: 25788
Penta | [98, 5916, 13064, 5852, 96]
https://furybench.com/test/3258/
```
LTC
```
Elo   | 1.88 +- 1.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 51494 W: 12626 L: 12348 D: 26520
Penta | [16, 5527, 14392, 5787, 25]
https://furybench.com/test/3259/
```

Bench: 1733858