### PR TITLE
Fix minor/major hash updates after promotions

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -648,9 +648,9 @@ void Board::doMove(Move move, uint64_t newHash, NNUE* nnue) {
 
         hashes.nonPawnHash[stm] ^= ZOBRIST_PIECE_SQUARES[stm][promotionPiece][target];
         if (promotionPiece == Piece::KNIGHT || promotionPiece == Piece::BISHOP)
-            hashes.minorHash ^= ZOBRIST_PIECE_SQUARES[flip(stm)][promotionPiece][captureTarget];
+            hashes.minorHash ^= ZOBRIST_PIECE_SQUARES[stm][promotionPiece][captureTarget];
         else
-            hashes.majorHash ^= ZOBRIST_PIECE_SQUARES[flip(stm)][promotionPiece][captureTarget];
+            hashes.majorHash ^= ZOBRIST_PIECE_SQUARES[stm][promotionPiece][captureTarget];
 
         break;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.4";
+constexpr auto VERSION = "7.0.5";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 2.95 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 29326 W: 7190 L: 6941 D: 15195
Penta | [49, 3199, 7928, 3428, 59]
https://furybench.com/test/3301/
```

Bench: 2285409