### PR TITLE
Reduce quiet moves less if the static eval has improved since our last move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1078,6 +1078,8 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
             else {
                 reduction -= 100 * moveHistory / lmrQuietHistoryDivisor;
                 reduction -= lmrQuietPvNodeOffset * pvNode;
+
+                reduction -= 50 * improving;
             }
 
             int reducedDepth = std::clamp(newDepth - reduction, 100, newDepth + 100) + lmrPvNodeExtension * pvNode;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.10";
+constexpr auto VERSION = "7.0.11";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.14 +- 0.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 133318 W: 32607 L: 32168 D: 68543
Penta | [268, 15118, 35436, 15581, 256]
https://furybench.com/test/3515/
```
LTC
```
Elo   | 2.89 +- 1.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 28448 W: 7001 L: 6764 D: 14683
Penta | [6, 2981, 8011, 3222, 4]
https://furybench.com/test/3524/
```

Bench: 2709036