### PR TITLE
Fix reduction table indexing for moveloop pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -928,7 +928,7 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
             && board->hasNonPawns()
             ) {
 
-            int16_t lmrDepth = std::max(0, depth - REDUCTIONS[!capture][depth / 100][moveCount] - earlyLmrImproving * !improving + 100 * moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
+            int16_t lmrDepth = std::max(0, depth - REDUCTIONS[capture][depth / 100][moveCount] - earlyLmrImproving * !improving + 100 * moveHistory / (capture ? earlyLmrHistoryFactorCapture : earlyLmrHistoryFactorQuiet));
 
             if (!movegen.skipQuiets) {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.13";
+constexpr auto VERSION = "7.0.15";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Passes non-regression
```
Elo   | 0.82 +- 1.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.78 (-2.25, 2.89) [0.00, 2.50]
Games | N: 96992 W: 23564 L: 23336 D: 50092
Penta | [203, 11153, 25532, 11429, 179]
https://furybench.com/test/3560/
```

Bench: 2820931