### PR TITLE
Tune search for 7.5k iterations

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -8,43 +8,43 @@
 #include "spsa.h"
 
 // Quiet history
-TUNE_INT(historyBonusQuietBase, 97, -500, 500);
-TUNE_INT(historyBonusQuietFactor, 265, 1, 500);
-TUNE_INT(historyBonusQuietMax, 2275, 32, 4096);
-TUNE_INT(historyMalusQuietBase, 73, -500, 500);
-TUNE_INT(historyMalusQuietFactor, 236, 1, 500);
-TUNE_INT(historyMalusQuietMax, 1428, 32, 4096);
+TUNE_INT(historyBonusQuietBase, 138, -500, 500);
+TUNE_INT(historyBonusQuietFactor, 262, 1, 500);
+TUNE_INT(historyBonusQuietMax, 2124, 32, 4096);
+TUNE_INT(historyMalusQuietBase, 100, -500, 500);
+TUNE_INT(historyMalusQuietFactor, 241, 1, 500);
+TUNE_INT(historyMalusQuietMax, 1482, 32, 4096);
 
 // Continuation history
-TUNE_INT(historyBonusContinuationBase, -75, -500, 500);
-TUNE_INT(historyBonusContinuationFactor, 169, 1, 500);
-TUNE_INT(historyBonusContinuationMax, 2082, 32, 4096);
-TUNE_INT(historyMalusContinuationBase, 123, -500, 500);
-TUNE_INT(historyMalusContinuationFactor, 226, 1, 500);
-TUNE_INT(historyMalusContinuationMax, 980, 32, 4096);
+TUNE_INT(historyBonusContinuationBase, -73, -500, 500);
+TUNE_INT(historyBonusContinuationFactor, 128, 1, 500);
+TUNE_INT(historyBonusContinuationMax, 2103, 32, 4096);
+TUNE_INT(historyMalusContinuationBase, 96, -500, 500);
+TUNE_INT(historyMalusContinuationFactor, 239, 1, 500);
+TUNE_INT(historyMalusContinuationMax, 813, 32, 4096);
 
 // Pawn history
-TUNE_INT(historyBonusPawnBase, 40, -500, 500);
-TUNE_INT(historyBonusPawnFactor, 151, 1, 500);
-TUNE_INT(historyBonusPawnMax, 2251, 32, 4096);
-TUNE_INT(historyMalusPawnBase, 47, -500, 500);
-TUNE_INT(historyMalusPawnFactor, 265, 1, 500);
-TUNE_INT(historyMalusPawnMax, 1964, 32, 4096);
+TUNE_INT(historyBonusPawnBase, 33, -500, 500);
+TUNE_INT(historyBonusPawnFactor, 172, 1, 500);
+TUNE_INT(historyBonusPawnMax, 2059, 32, 4096);
+TUNE_INT(historyMalusPawnBase, 30, -500, 500);
+TUNE_INT(historyMalusPawnFactor, 276, 1, 500);
+TUNE_INT(historyMalusPawnMax, 2104, 32, 4096);
 
 // Capture history
-TUNE_INT(historyBonusCaptureBase, 25, -500, 500);
-TUNE_INT(historyBonusCaptureFactor, 133, 1, 500);
-TUNE_INT(historyBonusCaptureMax, 1626, 32, 4096);
-TUNE_INT(historyMalusCaptureBase, 111, -500, 500);
-TUNE_INT(historyMalusCaptureFactor, 224, 1, 500);
-TUNE_INT(historyMalusCaptureMax, 1707, 32, 4096);
+TUNE_INT(historyBonusCaptureBase, 24, -500, 500);
+TUNE_INT(historyBonusCaptureFactor, 115, 1, 500);
+TUNE_INT(historyBonusCaptureMax, 1411, 32, 4096);
+TUNE_INT(historyMalusCaptureBase, 94, -500, 500);
+TUNE_INT(historyMalusCaptureFactor, 241, 1, 500);
+TUNE_INT(historyMalusCaptureMax, 1567, 32, 4096);
 
 // Correction history
-TUNE_INT(pawnCorrectionFactor, 6477, 1000, 7500);
-TUNE_INT(nonPawnCorrectionFactor, 5848, 1000, 7500);
-TUNE_INT(minorCorrectionFactor, 3411, 1000, 7500);
-TUNE_INT(majorCorrectionFactor, 2860, 1000, 7500);
-TUNE_INT(continuationCorrectionFactor, 5890, 1000, 7500);
+TUNE_INT(pawnCorrectionFactor, 6401, 1000, 7500);
+TUNE_INT(nonPawnCorrectionFactor, 6018, 1000, 7500);
+TUNE_INT(minorCorrectionFactor, 3783, 1000, 7500);
+TUNE_INT(majorCorrectionFactor, 2693, 1000, 7500);
+TUNE_INT(continuationCorrectionFactor, 5801, 1000, 7500);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -40,120 +40,120 @@ TUNE_FLOAT_DISABLED(tmNodesFactor, 0.9741686475516691f, 0.1f, 2.5f);
 TUNE_INT_DISABLED(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT_DISABLED(aspirationWindowDelta, 14, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowDeltaBase, 10, 1, 30);
-TUNE_INT(aspirationWindowDeltaDivisor, 12693, 7500, 17500);
+TUNE_INT(aspirationWindowDeltaDivisor, 13032, 7500, 17500);
 TUNE_INT_DISABLED(aspirationWindowMaxFailHighs, 3, 1, 10);
 TUNE_FLOAT_DISABLED(aspirationWindowDeltaFactor, 1.5804938062670641f, 1.0f, 3.0f);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.12746863537099537f, -2.0f, -0.1f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.1903164649052904f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.3079690761143748f, -2.0f, -0.1f);
-TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.217064038421647f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 1.1268698493886213f, 0.50f, 1.5f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.8894080400600535f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.11179712725778632f, -2.0f, -0.1f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 3.130045083882443f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.2037031842229747f, -2.0f, -0.1f);
+TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.1810657117079457f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 1.1606592351964504f, 0.50f, 1.5f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.909469676444663f, 2.0f, 4.0f);
 
-TUNE_FLOAT(seeMarginNoisy, -22.11307898299037f, -50.0f, -10.0f);
-TUNE_FLOAT(seeMarginQuiet, -74.50214592661511f, -100.0f, -50.0f);
-TUNE_FLOAT(lmpMarginWorseningBase, 1.9091638801582127f, -1.0f, 2.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.4523037982670635f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.6743536132963186f, 1.0f, 3.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 2.6292752518053866f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 0.8162098281205722f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 2.014946412827058f, 1.0f, 3.0f);
+TUNE_FLOAT(seeMarginNoisy, -22.140702810190852f, -50.0f, -10.0f);
+TUNE_FLOAT(seeMarginQuiet, -73.48234138042687f, -100.0f, -50.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.8639912522039657f, -1.0f, 2.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.4122803433523727f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.5666560928932445f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 2.741810009419904f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 0.7984448433062328f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 2.0331756453343477f, 1.0f, 3.0f);
 
 // Search values
-TUNE_INT(qsFutilityOffset, 76, 1, 125);
-TUNE_INT(qsSeeMargin, -69, -200, 50);
+TUNE_INT(qsFutilityOffset, 81, 1, 125);
+TUNE_INT(qsSeeMargin, -71, -200, 50);
 
 // Pre-search pruning
-TUNE_INT(ttCutOffset, 40, -100, 200);
-TUNE_INT(ttCutFailHighMargin, 118, 0, 200);
+TUNE_INT(ttCutOffset, 41, -100, 200);
+TUNE_INT(ttCutFailHighMargin, 121, 0, 200);
 
-TUNE_INT(iirMinDepth, 266, 100, 1000);
-TUNE_INT(iirLowTtDepthOffset, 418, 0, 800);
+TUNE_INT(iirMinDepth, 257, 100, 1000);
+TUNE_INT(iirLowTtDepthOffset, 424, 0, 800);
 TUNE_INT(iirReduction, 90, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -82, -500, -1);
-TUNE_INT(staticHistoryMin, -162, -1000, -1);
-TUNE_INT(staticHistoryMax, 313, 1, 1000);
-TUNE_INT(staticHistoryTempo, 27, 1, 200);
+TUNE_INT(staticHistoryFactor, -102, -500, -1);
+TUNE_INT(staticHistoryMin, -149, -1000, -1);
+TUNE_INT(staticHistoryMax, 278, 1, 1000);
+TUNE_INT(staticHistoryTempo, 30, 1, 200);
 
-TUNE_INT(rfpDepth, 1072, 200, 2000);
-TUNE_INT(rfpBase, 0, -100, 100);
-TUNE_INT(rfpFactorLinear, 42, 1, 250);
-TUNE_INT(rfpFactorQuadratic, 600, 1, 1800);
+TUNE_INT(rfpDepth, 1097, 200, 2000);
+TUNE_INT(rfpBase, 11, -100, 100);
+TUNE_INT(rfpFactorLinear, 31, 1, 250);
+TUNE_INT(rfpFactorQuadratic, 655, 1, 1800);
 TUNE_INT(rfpImprovingOffset, 100, 1, 200);
-TUNE_INT(rfpBaseCheck, 0, -100, 100);
-TUNE_INT(rfpFactorLinearCheck, 42, 1, 250);
-TUNE_INT(rfpFactorQuadraticCheck, 600, 1, 1800);
+TUNE_INT(rfpBaseCheck, -5, -100, 100);
+TUNE_INT(rfpFactorLinearCheck, 40, 1, 250);
+TUNE_INT(rfpFactorQuadraticCheck, 546, 1, 1800);
 TUNE_INT(rfpImprovingOffsetCheck, 100, 1, 200);
 
-TUNE_INT(razoringDepth, 535, 200, 2000);
-TUNE_INT(razoringFactor, 292, 1, 1000);
+TUNE_INT(razoringDepth, 493, 200, 2000);
+TUNE_INT(razoringFactor, 276, 1, 1000);
 
-TUNE_INT(nmpMinDepth, 339, 0, 600);
-TUNE_INT(nmpRedBase, 357, 100, 800);
-TUNE_INT(nmpDepthDiv, 262, 100, 600);
-TUNE_INT(nmpMin, 396, 100, 800);
+TUNE_INT(nmpMinDepth, 334, 0, 600);
+TUNE_INT(nmpRedBase, 353, 100, 800);
+TUNE_INT(nmpDepthDiv, 263, 100, 600);
+TUNE_INT(nmpMin, 372, 100, 800);
 TUNE_INT(nmpDivisor, 223, 10, 600);
 TUNE_INT(nmpEvalDepth, 7, 1, 100);
-TUNE_INT(nmpEvalBase, 149, 50, 300);
+TUNE_INT(nmpEvalBase, 158, 50, 300);
 
-TUNE_INT(probcutReduction, 408, 0, 600);
-TUNE_INT(probCutBetaOffset, 198, 1, 500);
-TUNE_INT(probCutDepth, 548, 100, 1000);
+TUNE_INT(probcutReduction, 437, 0, 600);
+TUNE_INT(probCutBetaOffset, 201, 1, 500);
+TUNE_INT(probCutDepth, 581, 100, 1000);
 
-TUNE_INT(iir2Reduction, 105, 0, 200);
+TUNE_INT(iir2Reduction, 102, 0, 200);
 
 // In-search pruning
-TUNE_INT(earlyLmrImproving, 137, 1, 500);
+TUNE_INT(earlyLmrImproving, 130, 1, 500);
 
-TUNE_INT(earlyLmrHistoryFactorQuiet, 16433, 10000, 20000);
-TUNE_INT(earlyLmrHistoryFactorCapture, 14945, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorQuiet, 15941, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorCapture, 14387, 10000, 20000);
 
-TUNE_INT(fpDepth, 1045, 100, 2000);
-TUNE_INT(fpBase, 283, 1, 1000);
+TUNE_INT(fpDepth, 1078, 100, 2000);
+TUNE_INT(fpBase, 306, 1, 1000);
 TUNE_INT(fpFactor, 70, 1, 500);
-TUNE_INT(fpPvNode, 30, 1, 250);
-TUNE_INT(fpPvNodeBadCapture, 103, 1, 500);
+TUNE_INT(fpPvNode, 39, 1, 250);
+TUNE_INT(fpPvNodeBadCapture, 118, 1, 500);
 
-TUNE_INT(fpCaptDepth, 838, 100, 2000);
-TUNE_INT(fpCaptBase, 430, 150, 750);
-TUNE_INT(fpCaptFactor, 411, 100, 600);
+TUNE_INT(fpCaptDepth, 763, 100, 2000);
+TUNE_INT(fpCaptBase, 415, 150, 750);
+TUNE_INT(fpCaptFactor, 419, 100, 600);
 
-TUNE_INT(historyPruningDepth, 438, 100, 1000);
-TUNE_INT(historyPruningFactorCapture, -2204, -8192, -128);
-TUNE_INT(historyPruningFactorQuiet, -6476, -8192, -128);
+TUNE_INT(historyPruningDepth, 480, 100, 1000);
+TUNE_INT(historyPruningFactorCapture, -2169, -8192, -128);
+TUNE_INT(historyPruningFactorQuiet, -6430, -8192, -128);
 
-TUNE_INT(extensionMinDepth, 667, 0, 1200);
-TUNE_INT(extensionTtDepthOffset, 447, 0, 600);
-TUNE_INT(doubleExtensionDepthIncreaseFactor, 97, 0, 200);
+TUNE_INT(extensionMinDepth, 660, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 455, 0, 600);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 93, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
-TUNE_INT(doubleExtensionDepthIncrease, 1080, 200, 2000);
+TUNE_INT(doubleExtensionDepthIncrease, 1063, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT(lmrMinDepth, 291, 100, 600);
+TUNE_INT(lmrMinDepth, 285, 100, 600);
 
-TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 143, 0, 500);
-TUNE_INT(lmrReductionOffsetImportantCapture, 14, 0, 500);
-TUNE_INT(lmrCheckQuietOrNormalCapture, 89, 0, 500);
+TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 150, 0, 500);
+TUNE_INT(lmrReductionOffsetImportantCapture, 5, 0, 500);
+TUNE_INT(lmrCheckQuietOrNormalCapture, 115, 0, 500);
 TUNE_INT(lmrCheckImportantCapture, 56, 0, 500);
-TUNE_INT(lmrTtPvQuietOrNormalCapture, 213, 0, 500);
-TUNE_INT(lmrTtPvImportantCapture, 184, 0, 500);
-TUNE_INT(lmrCutnode, 252, 0, 500);
-TUNE_INT(lmrTtpvFaillowQuietOrNormalCapture, 66, 0, 500);
-TUNE_INT(lmrTtpvFaillowImportantCapture, 79, 0, 500);
-TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 142542, 10000, 200000);
-TUNE_INT(lmrCorrectionDivisorImportantCapture, 146733, 10000, 200000);
-TUNE_INT(lmrQuietHistoryDivisor, 28404, 10000, 30000);
-TUNE_INT(lmrHistoryFactorCapture, 3068670, 2500000, 4000000);
-TUNE_INT(lmrHistoryFactorImportantCapture, 2988932, 2500000, 4000000);
-TUNE_INT(lmrImportantBadCaptureOffset, 102, 0, 500);
-TUNE_INT(lmrImportantCaptureFactor, 51, 0, 250);
-TUNE_INT(lmrQuietPvNodeOffset, 18, 0, 250);
-TUNE_INT(lmrQuietImproving, 50, 0, 250);
+TUNE_INT(lmrTtPvQuietOrNormalCapture, 206, 0, 500);
+TUNE_INT(lmrTtPvImportantCapture, 206, 0, 500);
+TUNE_INT(lmrCutnode, 264, 0, 500);
+TUNE_INT(lmrTtpvFaillowQuietOrNormalCapture, 46, 0, 500);
+TUNE_INT(lmrTtpvFaillowImportantCapture, 85, 0, 500);
+TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 142842, 10000, 200000);
+TUNE_INT(lmrCorrectionDivisorImportantCapture, 145933, 10000, 200000);
+TUNE_INT(lmrQuietHistoryDivisor, 29208, 10000, 30000);
+TUNE_INT(lmrHistoryFactorCapture, 3059928, 2500000, 4000000);
+TUNE_INT(lmrHistoryFactorImportantCapture, 2993600, 2500000, 4000000);
+TUNE_INT(lmrImportantBadCaptureOffset, 115, 0, 500);
+TUNE_INT(lmrImportantCaptureFactor, 33, 0, 250);
+TUNE_INT(lmrQuietPvNodeOffset, 17, 0, 250);
+TUNE_INT(lmrQuietImproving, 58, 0, 250);
 
 inline int lmrReductionOffset(bool importantCapture) { return importantCapture ? lmrReductionOffsetImportantCapture : lmrReductionOffsetQuietOrNormalCapture; };
 inline int lmrCheck(bool importantCapture) { return importantCapture ? lmrCheckImportantCapture : lmrCheckQuietOrNormalCapture; };
@@ -162,28 +162,28 @@ inline int lmrTtpvFaillow(bool importantCapture) { return importantCapture ? lmr
 inline int lmrCaptureHistoryDivisor(bool importantCapture) { return importantCapture ? lmrHistoryFactorImportantCapture : lmrHistoryFactorCapture; };
 inline int lmrCorrectionDivisor(bool importantCapture) { return importantCapture ? lmrCorrectionDivisorImportantCapture : lmrCorrectionDivisorQuietOrNormalCapture; };
 
-TUNE_INT(postlmrOppWorseningThreshold, 263, 150, 450);
+TUNE_INT(postlmrOppWorseningThreshold, 257, 150, 450);
 TUNE_INT(postlmrOppWorseningReduction, 142, 0, 200);
 
-TUNE_INT(lmrPvNodeExtension, 106, 0, 200);
+TUNE_INT(lmrPvNodeExtension, 107, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
-TUNE_INT(lmrDeeperWeight, 109, 0, 200);
-TUNE_INT(lmrShallowerWeight, 112, 0, 200);
-TUNE_INT(lmrResearchSkipDepthOffset, 400, 0, 800);
+TUNE_INT(lmrDeeperWeight, 106, 0, 200);
+TUNE_INT(lmrShallowerWeight, 110, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 408, 0, 800);
 
-TUNE_INT(lmrPassBonusBase, -262, -500, 500);
-TUNE_INT(lmrPassBonusFactor, 166, 1, 500);
-TUNE_INT(lmrPassBonusMax, 1024, 32, 4096);
+TUNE_INT(lmrPassBonusBase, -260, -500, 500);
+TUNE_INT(lmrPassBonusFactor, 148, 1, 500);
+TUNE_INT(lmrPassBonusMax, 1044, 32, 4096);
 
-TUNE_INT(historyDepthBetaOffset, 203, 1, 500);
+TUNE_INT(historyDepthBetaOffset, 210, 1, 500);
 
-TUNE_INT(lowDepthPvDepthReductionMin, 439, 0, 800);
-TUNE_INT(lowDepthPvDepthReductionMax, 1100, 0, 2000);
-TUNE_INT(lowDepthPvDepthReductionWeight, 113, 0, 200);
+TUNE_INT(lowDepthPvDepthReductionMin, 446, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1150, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 117, 0, 200);
 
-TUNE_INT(correctionHistoryFactor, 127, 32, 512);
-TUNE_INT(correctionHistoryFactorMulticut, 149, 32, 512);
+TUNE_INT(correctionHistoryFactor, 110, 32, 512);
+TUNE_INT(correctionHistoryFactorMulticut, 162, 32, 512);
 
 int REDUCTIONS[3][MAX_PLY][MAX_MOVES];
 int SEE_MARGIN[MAX_PLY][2];

--- a/src/spsa.h
+++ b/src/spsa.h
@@ -92,7 +92,7 @@ public:
 
 };
 
-#define TUNE_ENABLED true
+#define TUNE_ENABLED false
 
 // Some fancy macro stuff to call the tune() methods inline from anywhere
 #define STRINGIFY(x) #x

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -2,8 +2,8 @@
 #include "move.h"
 #include "spsa.h"
 
-TUNE_INT(ttReplaceTtpvBonus, 215, 0, 400);
-TUNE_INT(ttReplaceOffset, 448, 0, 800);
+TUNE_INT(ttReplaceTtpvBonus, 214, 0, 400);
+TUNE_INT(ttReplaceOffset, 451, 0, 800);
 
 void TTEntry::update(uint64_t _hash, Move _bestMove, int16_t _depth, Eval _eval, Eval _value, uint8_t _rule50, bool wasPv, int _flags) {
     // Update bestMove if not MOVE_NONE

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.15";
+constexpr auto VERSION = "7.0.16";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 0.11 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 2.50]
Games | N: 107084 W: 26065 L: 26030 D: 54989
Penta | [175, 12413, 28350, 12410, 194]
https://furybench.com/test/3600/
```
VLTC
```
Elo   | 2.11 +- 1.53 (95%)
SPRT  | 80.0+0.80s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 41356 W: 10382 L: 10131 D: 20843
Penta | [7, 4144, 12123, 4399, 5]
https://furybench.com/test/3604/
```

Bench: 2124849