### PR TITLE
Adjust correction history in multicut based on singularValue

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1020,8 +1020,8 @@ Eval Worker::search(Board* board, SearchStack* stack, int16_t depth, Eval alpha,
                 ttEntry->update(board->hashes.hash, ttMove, singularDepth, unadjustedEval, value, board->rule50_ply, stack->ttPv, TT_LOWERBOUND);
 
                 // Adjust correction history
-                if (!board->checkers && value > stack->staticEval) {
-                    int bonus = std::clamp((int(value - stack->staticEval) * singularDepth / 100) * correctionHistoryFactorMulticut / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
+                if (!board->checkers && singularValue > stack->staticEval) {
+                    int bonus = std::clamp((int(singularValue - stack->staticEval) * singularDepth / 100) * correctionHistoryFactorMulticut / 1024, -CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
                     history.updateCorrectionHistory(board, stack, bonus);
                 }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.17";
+constexpr auto VERSION = "7.0.18";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.21 +- 1.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.67 (-2.25, 2.89) [0.00, 2.50]
Games | N: 59978 W: 14912 L: 14703 D: 30363
Penta | [11, 6373, 17016, 6574, 15]
```
https://furybench.com/test/3657/