### PR TITLE
Fix time management with fixed time per move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1475,7 +1475,7 @@ void Worker::iterativeDeepening() {
             // Based on fraction of nodes that went into the best move
             tmAdjustment *= tmNodesBase - tmNodesFactor * ((double)rootMoveNodes[rootMoves[0].move] / (double)searchData.nodesSearched);
 
-            if (timeOverDepthCleared(searchParameters, searchData, tmAdjustment)) {
+            if (searchData.doSoftTM && timeOverDepthCleared(searchParameters, searchData, tmAdjustment)) {
                 threadPool->stopSearching();
                 return;
             }

--- a/src/search.h
+++ b/src/search.h
@@ -75,6 +75,7 @@ struct SearchData {
     int64_t startTime;
     int64_t optTime;
     int64_t maxTime;
+    bool doSoftTM;
 
     SearchData() {
         nmpPlies = 0;
@@ -84,6 +85,7 @@ struct SearchData {
         startTime = 0;
         optTime = 0;
         maxTime = 0;
+        doSoftTM = true;
     }
 };
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -31,6 +31,7 @@ bool timeOverDepthCleared(SearchParameters& parameters, SearchData& data, double
 void initTimeManagement(Board& rootBoard, SearchParameters& parameters, SearchData& data) {
     data.startTime = getTime();
     data.maxTime = 0;
+    data.doSoftTM = true;
 
     if (UCI::Options.datagen.value)
         return;
@@ -57,6 +58,7 @@ void initTimeManagement(Board& rootBoard, SearchParameters& parameters, SearchDa
     if (parameters.movetime) {
         data.optTime = data.startTime + time;
         data.maxTime = data.startTime + time;
+        data.doSoftTM = false;
     }
     else if (parameters.movestogo) {
         int64_t totalTime = time / parameters.movestogo;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.19";
+constexpr auto VERSION = "7.0.20";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 22.39 +- 5.76 (95%)
SPRT  | MT=1000 Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 3014 W: 874 L: 680 D: 1460
Penta | [0, 236, 842, 428, 1]
```
https://furybench.com/test/3698/

Bench: 1829595