### PR TITLE
Stockfish-style threat feature lookup tables

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -80,7 +80,7 @@ void NNUE::resetAccumulator(Board* board, Accumulator* acc) {
     memset(acc->pieceState[side], 0, sizeof(acc->pieceState[side]));
 
     ThreatInputs::FeatureList threatFeatures;
-    ThreatInputs::addThreatFeatures(board, side, threatFeatures);
+    ThreatInputs::addThreatFeatures<side>(board, threatFeatures);
     for (int featureIndex : threatFeatures)
         addToAccumulator<true, side>(acc->threatState, acc->threatState, featureIndex);
 
@@ -207,7 +207,7 @@ void NNUE::refreshThreatFeatures(Accumulator* acc) {
     memcpy(acc->threatState[side], networkData->inputBiases, sizeof(networkData->inputBiases));
 
     ThreatInputs::FeatureList threatFeatures;
-    ThreatInputs::addThreatFeatures(acc->board, side, threatFeatures);
+    ThreatInputs::addThreatFeatures<side>(acc->board, threatFeatures);
     for (int featureIndex : threatFeatures)
         addToAccumulator<true, side>(acc->threatState, acc->threatState, featureIndex);
 }
@@ -241,14 +241,11 @@ void NNUE::incrementallyUpdateThreatFeatures(Accumulator* inputAcc, Accumulator*
     ThreatInputs::FeatureList addFeatures, subFeatures;
 
     for (int dp = 0; dp < outputAcc->numDirtyThreats; dp++) {
-        DirtyThreat& dirtyThreat = outputAcc->dirtyThreats[dp];
+        DirtyThreat& dt = outputAcc->dirtyThreats[dp];
 
-        size_t featureIndex = ThreatInputs::lookupThreatFeature<side>(dirtyThreat.piece, dirtyThreat.pieceColor, dirtyThreat.square, dirtyThreat.attackedSquare, dirtyThreat.attackedPiece, dirtyThreat.attackedColor, kingBucket->mirrored);
-        if (featureIndex != ThreatInputs::PieceOffsets::TOTAL) {
-            if (dirtyThreat.add)
-                addFeatures.add(featureIndex);
-            else
-                subFeatures.add(featureIndex);
+        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.pieceColor, dt.square, dt.attackedSquare, dt.attackedPiece, dt.attackedColor, kingBucket->mirrored);
+        if (featureIndex < ThreatInputs::FEATURE_COUNT) {
+            (dt.add ? addFeatures : subFeatures).add(featureIndex);
         }
     }
 

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -19,7 +19,7 @@ constexpr uint8_t KING_BUCKET_LAYOUT[] = {
 };
 constexpr int KING_BUCKETS = 12;
 
-constexpr int INPUT_SIZE = 2 * ThreatInputs::PieceOffsets::END + 768 * KING_BUCKETS;
+constexpr int INPUT_SIZE = ThreatInputs::FEATURE_COUNT + 768 * KING_BUCKETS;
 constexpr int L1_SIZE = 640;
 constexpr int L2_SIZE = 16;
 constexpr int L3_SIZE = 32;
@@ -94,7 +94,7 @@ struct FinnyEntry {
 
 struct NetworkData {
   alignas(ALIGNMENT) int16_t inputPsqWeights[768 * KING_BUCKETS * L1_SIZE];
-  alignas(ALIGNMENT) int8_t inputThreatWeights[2 * ThreatInputs::PieceOffsets::END * L1_SIZE];
+  alignas(ALIGNMENT) int8_t inputThreatWeights[ThreatInputs::FEATURE_COUNT * L1_SIZE];
   alignas(ALIGNMENT) int16_t inputBiases[L1_SIZE];
   alignas(ALIGNMENT) int8_t  l1Weights[OUTPUT_BUCKETS][L1_SIZE * L2_SIZE];
   alignas(ALIGNMENT) float   l1Biases[OUTPUT_BUCKETS][L2_SIZE];
@@ -201,7 +201,7 @@ public:
   }
 
   int16_t oldInputPsqWeights[768 * KING_BUCKETS * L1_SIZE];
-  int8_t oldInputThreatWeights[2 * ThreatInputs::PieceOffsets::END * L1_SIZE];
+  int8_t oldInputThreatWeights[ThreatInputs::FEATURE_COUNT * L1_SIZE];
   int16_t oldInputBiases[L1_SIZE];
   int8_t  oldL1Weights[OUTPUT_BUCKETS][L1_SIZE * L2_SIZE];
   NetworkData nnzOutNet;
@@ -234,7 +234,7 @@ public:
         nnzOutNet.inputPsqWeights[ip * L1_SIZE + l1] = oldInputPsqWeights[ip * L1_SIZE + order[l1]];
         nnzOutNet.inputPsqWeights[ip * L1_SIZE + l1 + L1_SIZE / 2] = oldInputPsqWeights[ip * L1_SIZE + order[l1] + L1_SIZE / 2];
       }
-      for (int ip = 0; ip < 2 * ThreatInputs::PieceOffsets::END; ip++) {
+      for (int ip = 0; ip < ThreatInputs::FEATURE_COUNT; ip++) {
         nnzOutNet.inputThreatWeights[ip * L1_SIZE + l1] = oldInputThreatWeights[ip * L1_SIZE + order[l1]];
         nnzOutNet.inputThreatWeights[ip * L1_SIZE + l1 + L1_SIZE / 2] = oldInputThreatWeights[ip * L1_SIZE + order[l1] + L1_SIZE / 2];
       }

--- a/src/threat-inputs.cpp
+++ b/src/threat-inputs.cpp
@@ -4,37 +4,129 @@
 
 namespace ThreatInputs {
 
-    int INDEX_LOOKUP[6][64][64][6][2][2];
+    struct PiecePairData {
+        // Bit 0: Excluded if origin < target
+        // Bit 1: Always excluded
+        // Bits 8-31: Base feature
+        uint32_t data;
 
-    // Count how many attacked squares are < to, effectively creating an index for the "to" square relative to the "from" square
-    int localThreatIndex(Square to, Bitboard attackedByFrom) {
-        return BB::popcount(attackedByFrom & (bitboard(to) - 1));
+        PiecePairData() {}
+        PiecePairData(bool excluded, bool semiExcluded, int baseFeature) {
+            data = (semiExcluded && !excluded) | (excluded << 1) | (baseFeature << 8);
+        }
+
+        bool isExcluded(Square attackingSquare, Square attackedSquare) const {
+            bool lessThan = attackingSquare < attackedSquare;
+            return (((uint8_t)data + lessThan) & 2);
+        }
+        int baseFeature() const { return data >> 8; }
+    };
+
+    PiecePairData PIECE_PAIR_LOOKUP[6][2][6][2];
+    int PIECE_OFFSET_LOOKUP[6][2][64];
+    uint8_t ATTACK_INDEX_LOOKUP[6][2][64][64];
+
+    void initialise() {
+
+        constexpr int PIECE_INTERACTION_MAP[6][6] = {
+            {0,  1, -1,  2, -1, -1},
+            {0,  1,  2,  3,  4,  5},
+            {0,  1,  2,  3, -1,  4},
+            {0,  1,  2,  3, -1,  4},
+            {0,  1,  2,  3,  4,  5},
+            {0,  1,  2,  3, -1, -1}
+        };
+
+        constexpr int PIECE_TARGET_COUNT[6] = { 6, 12, 10, 10, 12, 8 };
+
+        int cumulativeOffset = 0;
+        int CUMULATIVE_PIECE_OFFSET[6][2];
+        int CUMULATIVE_OFFSET[6][2];
+        for (Color color = Color::WHITE; color <= Color::BLACK; ++color) {
+            for (Piece piece = Piece::PAWN; piece < Piece::TOTAL; ++piece) {
+                int cumulativePieceOffset = 0;
+
+                for (Square origin = 0; origin < 64; origin++) {
+                    PIECE_OFFSET_LOOKUP[piece][color][origin] = cumulativePieceOffset;
+
+                    if (piece != Piece::PAWN || (origin >= 8 && origin < 56)) {
+                        Bitboard attacks = BB::attackedSquares(piece, origin, 0, color);
+                        cumulativePieceOffset += BB::popcount(attacks);
+                    }
+                }
+
+                CUMULATIVE_PIECE_OFFSET[piece][color] = cumulativePieceOffset;
+                CUMULATIVE_OFFSET[piece][color] = cumulativeOffset;
+
+                cumulativeOffset += PIECE_TARGET_COUNT[piece] * cumulativePieceOffset;
+            }
+        }
+
+        for (Piece attackingPiece = Piece::PAWN; attackingPiece < Piece::TOTAL; ++attackingPiece) {
+            for (Piece attackedPiece = Piece::PAWN; attackedPiece < Piece::TOTAL; ++attackedPiece) {
+                for (Color attackingColor = Color::WHITE; attackingColor <= Color::BLACK; ++attackingColor) {
+                    for (Color attackedColor = Color::WHITE; attackedColor <= Color::BLACK; ++attackedColor) {
+
+                        int map = PIECE_INTERACTION_MAP[attackingPiece][attackedPiece];
+                        int featureBase = CUMULATIVE_OFFSET[attackingPiece][attackingColor] + (attackedColor * (PIECE_TARGET_COUNT[attackingPiece] / 2) + map) * CUMULATIVE_PIECE_OFFSET[attackingPiece][attackingColor];
+
+                        bool enemy = attackingColor != attackedColor;
+                        bool semiExcluded = attackingPiece == attackedPiece && (enemy || attackingPiece != Piece::PAWN);
+                        bool excluded = map < 0;
+
+                        PIECE_PAIR_LOOKUP[attackingPiece][attackingColor][attackedPiece][attackedColor] = PiecePairData(excluded, semiExcluded, featureBase);
+                    }
+                }
+            }
+        }
+
+        for (Piece piece = Piece::PAWN; piece < Piece::TOTAL; ++piece) {
+            for (Color color = Color::WHITE; color <= Color::BLACK; ++color) {
+                for (Square origin = 0; origin < 64; origin++) {
+                    for (Square target = 0; target < 64; target++) {
+                        Bitboard attacks = BB::attackedSquares(piece, origin, 0, color);
+                        ATTACK_INDEX_LOOKUP[piece][color][origin][target] = BB::popcount((bitboard(target) - 1) & attacks);
+                    }
+                }
+            }
+        }
     }
 
-    Bitboard mirrorBitboard(Bitboard bitboard) {
-        constexpr Bitboard K1 = 0x5555555555555555;
-        constexpr Bitboard K2 = 0x3333333333333333;
-        constexpr Bitboard K4 = 0x0f0f0f0f0f0f0f0f;
-        bitboard = ((bitboard >> 1) & K1) | ((bitboard & K1) << 1);
-        bitboard = ((bitboard >> 2) & K2) | ((bitboard & K2) << 2);
-        return ((bitboard >> 4) & K4) | ((bitboard & K4) << 4);
+    template<Color side>
+    int getThreatFeature(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored) {
+        uint8_t squareFlip = (7 * mirrored) ^ (56 * side);
+        attackingSquare ^= squareFlip;
+        attackedSquare ^= squareFlip;
+
+        attackingColor ^= side;
+        attackedColor ^= side;
+
+        auto piecePairData = PIECE_PAIR_LOOKUP[attackingPiece][attackingColor][attackedPiece][attackedColor];
+        if (piecePairData.isExcluded(attackingSquare, attackedSquare))
+            return FEATURE_COUNT;
+
+        int index = piecePairData.baseFeature()
+            + PIECE_OFFSET_LOOKUP[attackingPiece][attackingColor][attackingSquare]
+            + ATTACK_INDEX_LOOKUP[attackingPiece][attackingColor][attackingSquare][attackedSquare];
+
+        assert(index < FEATURE_COUNT);
+        return index;
+    }
+    template int getThreatFeature<Color::WHITE>(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
+    template int getThreatFeature<Color::BLACK>(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
+
+    int getPieceFeature(Piece piece, Square relativeSquare, Color relativeColor, uint8_t kingBucket) {
+        return 768 * kingBucket + 384 * relativeColor + 64 * piece + relativeSquare;
     }
 
-    void addThreatFeatures(Board* board, Color pov, FeatureList& features) {
+    template<Color pov>
+    void addThreatFeatures(Board* board, FeatureList& features) {
         // Check HM and get occupancies
         Square king = lsb(board->byColor[pov] & board->byPiece[Piece::KING]);
         bool hm = fileOf(king) >= 4;
 
-        Bitboard occupancy = board->byColor[Color::WHITE] | board->byColor[Color::BLACK];
-        if (hm) occupancy = mirrorBitboard(occupancy);
-        Bitboard nonPovOccupancy = board->byColor[flip(pov)];
-        if (hm) nonPovOccupancy = mirrorBitboard(nonPovOccupancy);
-
         // Loop through sides and pieces
         for (Color side = Color::WHITE; side <= Color::BLACK; ++side) {
-
-            Bitboard enemyOccupancy = board->byColor[flip(side)];
-            if (hm) enemyOccupancy = mirrorBitboard(enemyOccupancy);
 
             for (Piece piece = Piece::PAWN; piece < Piece::TOTAL; ++piece) {
                 Bitboard pieceBitboard = board->byColor[side] & board->byPiece[piece];
@@ -42,33 +134,26 @@ namespace ThreatInputs {
                 // Add features for this piece
                 while (pieceBitboard) {
                     Square indexSquare = popLSB(&pieceBitboard);
-                    Square square = indexSquare ^ (hm * 7);
-                    Square relativeSquare = square ^ (56 * pov);
 
                     // Add the threat features
                     Bitboard attacks = board->attackersTo(indexSquare);
-                    if (hm) attacks = mirrorBitboard(attacks);
                     while (attacks) {
                         Square attackingSquare = popLSB(&attacks);
-                        Square attackingIndexSquare = attackingSquare ^ (hm * 7);
-                        Square relativeAttackingSquare = attackingSquare ^ (56 * pov);
-                        Piece attackingPiece = board->pieces[attackingIndexSquare];
-                        Color attackingSide = (board->byColor[Color::WHITE] & bitboard(attackingIndexSquare)) ? Color::WHITE : Color::BLACK;
-
-                        Color relativeSide = static_cast<Color>(pov != side);
-                        bool enemy = attackingSide != side;
-                        int sideOffset = (attackingSide != pov) * PieceOffsets::END;
+                        Piece attackingPiece = board->pieces[attackingSquare];
+                        Color attackingSide = (board->byColor[Color::WHITE] & bitboard(attackingSquare)) ? Color::WHITE : Color::BLACK;
 
                         assert(attackingPiece != Piece::NONE);
 
-                        int threatFeature = getThreatFeature(attackingPiece, relativeAttackingSquare, relativeSquare, piece, relativeSide, enemy);
-                        if (threatFeature != -1)
-                            features.add(threatFeature + sideOffset);
+                        int threatFeature = getThreatFeature<pov>(attackingPiece, attackingSide, attackingSquare, indexSquare, piece, side, hm);
+                        if (threatFeature < FEATURE_COUNT)
+                            features.add(threatFeature);
                     }
                 }
             }
         }
     }
+    template void addThreatFeatures<Color::WHITE>(Board* board, FeatureList& features);
+    template void addThreatFeatures<Color::BLACK>(Board* board, FeatureList& features);
 
     void addPieceFeatures(Board* board, Color pov, FeatureList& features, const uint8_t* KING_BUCKET_LAYOUT) {
         // Check HM and get occupancies
@@ -92,269 +177,6 @@ namespace ThreatInputs {
                 }
             }
         }
-    }
-
-    int getPieceFeature(Piece piece, Square relativeSquare, Color relativeColor, uint8_t kingBucket) {
-        return 768 * kingBucket + 384 * relativeColor + 64 * piece + relativeSquare;
-    }
-
-    struct PiecePairData {
-        // Layout: bits 8..31 are the index contribution of this piece pair, bits 0 and 1 are exclusion info
-        uint32_t data;
-        PiecePairData() {}
-        PiecePairData(bool excluded_pair, bool semi_excluded_pair, size_t feature_index_base) {
-            data = excluded_pair << 1 | (semi_excluded_pair && !excluded_pair) | feature_index_base << 8;
-        }
-        // lsb: excluded if from < to; 2nd lsb: always excluded
-        uint8_t   excluded_pair_info() const { return (uint8_t)data; }
-        size_t feature_index_base() const { return data >> 8; }
-    };
-
-    PiecePairData PIECE_PAIR_LOOKUP[6][2][6][2];
-    size_t OFFSETS[6][2][64 + 2];
-    uint8_t REMAINDER_LOOKUP[6][2][64][64];
-
-    void initialise() {
-        memset(INDEX_LOOKUP, 0xFFFF, sizeof(INDEX_LOOKUP));
-
-        static constexpr int MAP[6][6] = {
-            {0,  1, -1,  2, -1, -1},
-            {0,  1,  2,  3,  4,  5},
-            {0,  1,  2,  3, -1,  4},
-            {0,  1,  2,  3, -1,  4},
-            {0,  1,  2,  3,  4,  5},
-            {0,  1,  2,  3, -1, -1}
-        };
-
-        static constexpr int NUM_VALID_TARGETS[6] = {6, 12, 10, 10, 12, 8};
-
-        int cumulativeOffset = 0;
-        for (Color color = Color::WHITE; color <= Color::BLACK; ++color) {
-            for (Piece piece = Piece::PAWN; piece < Piece::TOTAL; ++piece) {
-                int cumulativePieceOffset = 0;
-
-                for (Square origin = 0; origin < 64; origin++) {
-                    OFFSETS[piece][color][origin] = cumulativePieceOffset;
-
-                    if (piece != Piece::PAWN || (origin >= 8 && origin < 56)) {
-                        Bitboard attacks = BB::attackedSquares(piece, origin, 0, color);
-                        cumulativePieceOffset += BB::popcount(attacks);
-                    }
-                }
-
-                OFFSETS[piece][color][64] = cumulativePieceOffset;
-                OFFSETS[piece][color][65] = cumulativeOffset;
-
-                cumulativeOffset += NUM_VALID_TARGETS[piece] * cumulativePieceOffset;
-            }
-        }
-
-        for (Piece attackingPiece = Piece::PAWN; attackingPiece < Piece::TOTAL; ++attackingPiece) {
-            for (Piece attackedPiece = Piece::PAWN; attackedPiece < Piece::TOTAL; ++attackedPiece) {
-                for (Color attackingColor = Color::WHITE; attackingColor <= Color::BLACK; ++attackingColor) {
-                    for (Color attackedColor = Color::WHITE; attackedColor <= Color::BLACK; ++attackedColor) {
-
-                        int map = MAP[attackingPiece][attackedPiece];
-                        size_t feature = OFFSETS[attackingPiece][attackingColor][65] + (attackedColor * (NUM_VALID_TARGETS[attackingPiece] / 2) + map) * OFFSETS[attackingPiece][attackingColor][64];
-
-                        bool enemy = attackingColor != attackedColor;
-                        bool semiExcluded = attackingPiece == attackedPiece && (enemy || attackingPiece != Piece::PAWN);
-                        bool excluded = map < 0;
-
-                        PIECE_PAIR_LOOKUP[attackingPiece][attackingColor][attackedPiece][attackedColor] = PiecePairData(excluded, semiExcluded, feature);
-
-                        for (Color pov = Color::WHITE; pov <= Color::BLACK; ++pov) {
-                            for (Square attackingSquare = 0; attackingSquare < 64; attackingSquare++) {
-
-                                if (attackingPiece == Piece::PAWN && (attackingSquare < 8 || attackingSquare >= 56))
-                                    continue;
-
-                                Bitboard attacks = BB::attackedSquares(attackingPiece, attackingSquare, 0, attackingColor);
-                                assert(attacks > 0);
-                                while (attacks) {
-                                    Square attackedSquare = popLSB(&attacks);
-
-                                    Color relativeSide = static_cast<Color>(pov != attackedColor);
-                                    bool enemy = attackingColor != attackedColor;
-
-                                    int feature = getThreatFeature(attackingPiece, attackingSquare, attackedSquare, attackedPiece, relativeSide, enemy);
-                                    INDEX_LOOKUP[attackingPiece][attackingSquare][attackedSquare][attackedPiece][relativeSide][enemy] = feature;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        for (Piece piece = Piece::PAWN; piece < Piece::TOTAL; ++piece) {
-            for (Color color = Color::WHITE; color <= Color::BLACK; ++color) {
-                for (Square origin = 0; origin < 64; origin++) {
-                    for (Square target = 0; target < 64; target++) {
-                        Bitboard attacks = BB::attackedSquares(piece, origin, 0, color);
-                        REMAINDER_LOOKUP[piece][color][origin][target] = BB::popcount((bitboard(target) - 1) & attacks);
-                    }
-                }
-            }
-        }
-
-    }
-
-    template<Color side>
-    int lookupThreatFeature(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored) {
-        uint8_t squareFlip = (7 * mirrored) ^ (56 * side);
-        attackingSquare ^= squareFlip;
-        attackedSquare ^= squareFlip;
-
-        attackingColor ^= side;
-        attackedColor ^= side;
-
-        auto piecePairData = PIECE_PAIR_LOOKUP[attackingPiece][attackingColor][attackedPiece][attackedColor];
-        bool lessThan = attackingSquare < attackedSquare;
-        if ((piecePairData.excluded_pair_info() + lessThan) & 2)
-            return PieceOffsets::TOTAL;
-        
-        size_t index = piecePairData.feature_index_base() + OFFSETS[attackingPiece][attackingColor][attackingSquare] + REMAINDER_LOOKUP[attackingPiece][attackingColor][attackingSquare][attackedSquare];
-        assert(piecePairData.feature_index_base() < PieceOffsets::TOTAL);
-        assert(OFFSETS[attackingPiece][attackingColor][attackingSquare] < PieceOffsets::TOTAL);
-        assert(REMAINDER_LOOKUP[attackingPiece][attackingColor][attackingSquare][attackedSquare] < PieceOffsets::TOTAL);
-        assert(index < PieceOffsets::TOTAL);
-        return index;
-    }
-    template int lookupThreatFeature<Color::WHITE>(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
-    template int lookupThreatFeature<Color::BLACK>(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
-
-    int getThreatFeature(Piece piece, Square from, Square to, Piece target, Color relativeSide, bool enemy) {
-        assert(piece != Piece::NONE);
-
-        int featureIndex;
-        switch (piece) {
-        case Piece::PAWN:
-            featureIndex = getPawnThreatFeature(from, to, target, relativeSide, enemy);
-            break;
-        case Piece::KNIGHT:
-            featureIndex = getKnightThreatFeature(from, to, target, relativeSide);
-            break;
-        case Piece::BISHOP:
-            featureIndex = getBishopThreatFeature(from, to, target, relativeSide);
-            break;
-        case Piece::ROOK:
-            featureIndex = getRookThreatFeature(from, to, target, relativeSide);
-            break;
-        case Piece::QUEEN:
-            featureIndex = getQueenThreatFeature(from, to, target, relativeSide);
-            break;
-        case Piece::KING:
-            featureIndex = getKingThreatFeature(from, to, target, relativeSide);
-            break;
-        case Piece::NONE:
-            featureIndex = -1;
-            assert(false);
-        }
-
-        return featureIndex;
-    }
-
-    int getPawnThreatFeature(Square from, Square to, Piece target, Color relativeSide, bool enemy) {
-        // Allow threats to pawns, knights and rooks
-        constexpr int OFFSETS[] = { 0, 1, MAX, 2, MAX, MAX, 3, 4, MAX, 5, MAX, MAX };
-
-        // Also skip enemy pawns with to > from to prevent duplicates
-        if (OFFSETS[target] == MAX || (enemy && to > from && target == Piece::PAWN))
-            return -1;
-
-        bool up = to > from;
-        int diff = std::abs(to - from);
-        int id = ((up && diff == 7) || (!up && diff == 9)) ? 0 : 1;
-        int attack = 2 * (from % 8) + id - 1;
-        int threat = PieceOffsets::PAWN + OFFSETS[target + 6 * relativeSide] * SquareThreatCounts::PAWN + (from / 8 - 1) * 14 + attack;
-
-        assert(threat >= PieceOffsets::PAWN);
-        assert(threat < PieceOffsets::KNIGHT);
-
-        return threat;
-    }
-
-    int getKnightThreatFeature(Square from, Square to, Piece target, Color relativeSide) {
-        // Allow threats to all piece types
-
-        // Skip knights with to > from to prevent duplicates
-        if (to > from && target == Piece::KNIGHT)
-            return -1;
-
-        int localIndex = SquareThreatCounts::KNIGHT[from] + localThreatIndex(to, BB::KNIGHT_ATTACKS[from]);
-        int threat = PieceOffsets::KNIGHT + (target + 6 * relativeSide) * SquareThreatCounts::KNIGHT[64] + localIndex;
-
-        assert(threat >= PieceOffsets::KNIGHT);
-        assert(threat < PieceOffsets::BISHOP);
-
-        return threat;
-    }
-
-    int getBishopThreatFeature(Square from, Square to, Piece target, Color relativeSide) {
-        // Allow threats to everything but queens
-        constexpr int OFFSETS[] = { 0, 1, 2, 3, MAX, 4, 5, 6, 7, 8, MAX, 9 };
-
-        // Also skip bishops with to > from to prevent duplicates
-        if (OFFSETS[target] == MAX || (to > from && target == Piece::BISHOP))
-            return -1;
-
-        int localIndex = SquareThreatCounts::BISHOP[from] + localThreatIndex(to, getBishopMoves(from, 0));
-        int threat = PieceOffsets::BISHOP + OFFSETS[target + 6 * relativeSide] * SquareThreatCounts::BISHOP[64] + localIndex;
-
-        assert(threat >= PieceOffsets::BISHOP);
-        assert(threat < PieceOffsets::ROOK);
-
-        return threat;
-    }
-
-    int getRookThreatFeature(Square from, Square to, Piece target, Color relativeSide) {
-        // Allow threats to everything but queens
-        constexpr int OFFSETS[] = { 0, 1, 2, 3, MAX, 4, 5, 6, 7, 8, MAX, 9 };
-
-        // Also skip rooks with to > from to prevent duplicates
-        if (OFFSETS[target] == MAX || (to > from && target == Piece::ROOK))
-            return -1;
-
-        int localIndex = SquareThreatCounts::ROOK[from] + localThreatIndex(to, getRookMoves(from, 0));
-        int threat = PieceOffsets::ROOK + OFFSETS[target + 6 * relativeSide] * SquareThreatCounts::ROOK[64] + localIndex;
-
-        assert(threat >= PieceOffsets::ROOK);
-        assert(threat < PieceOffsets::QUEEN);
-
-        return threat;
-    }
-
-    int getQueenThreatFeature(Square from, Square to, Piece target, Color relativeSide) {
-        // Allow threats to all pieces
-
-        // Skip queens with to > from to prevent duplicates
-        if (to > from && target == Piece::QUEEN)
-            return -1;
-
-        int localIndex = SquareThreatCounts::QUEEN[from] + localThreatIndex(to, getRookMoves(from, 0) | getBishopMoves(from, 0));
-        int threat = PieceOffsets::QUEEN + (target + 6 * relativeSide) * SquareThreatCounts::QUEEN[64] + localIndex;
-
-        assert(threat >= PieceOffsets::QUEEN);
-        assert(threat < PieceOffsets::KING);
-
-        return threat;
-    }
-
-    int getKingThreatFeature(Square from, Square to, Piece target, Color relativeSide) {
-        // Allow threats to pawns, knights, bishops and rooks
-        constexpr int OFFSETS[] = { 0, 1, 2, 3, MAX, MAX, 4, 5, 6, 7, MAX, MAX };
-
-        if (OFFSETS[target] == MAX)
-            return -1;
-
-        int localIndex = SquareThreatCounts::KING[from] + localThreatIndex(to, BB::KING_ATTACKS[from]);
-        int threat = PieceOffsets::KING + OFFSETS[target + 6 * relativeSide] * SquareThreatCounts::KING[64] + localIndex;
-
-        assert(threat >= PieceOffsets::KING);
-        assert(threat < PieceOffsets::END);
-
-        return threat;
     }
 
 }

--- a/src/threat-inputs.h
+++ b/src/threat-inputs.h
@@ -13,6 +13,7 @@
 namespace ThreatInputs {
 
     constexpr int MAX_ACTIVE_FEATURES = 128;
+    constexpr int FEATURE_COUNT = 79856;
 
     class FeatureListIterator {
     public:
@@ -90,52 +91,15 @@ namespace ThreatInputs {
         int featureIndices[MAX_ACTIVE_FEATURES];
         int featureCount;
     };
-
-    namespace SquareThreatCounts {
-
-        constexpr int PAWN = 84;
-        constexpr int KNIGHT[] = { 0, 2, 5, 9, 13, 17, 21, 24, 26, 29, 33, 39, 45, 51, 57, 61, 64, 68, 74, 82, 90, 98, 106, 112, 116, 120, 126, 134, 142, 150, 158, 164, 168, 172, 178, 186, 194, 202, 210, 216, 220, 224, 230, 238, 246, 254, 262, 268, 272, 275, 279, 285, 291, 297, 303, 307, 310, 312, 315, 319, 323, 327, 331, 334, 336 };
-        constexpr int BISHOP[] = { 0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 72, 81, 90, 99, 108, 117, 124, 131, 140, 151, 162, 173, 184, 193, 200, 207, 216, 227, 240, 253, 264, 273, 280, 287, 296, 307, 320, 333, 344, 353, 360, 367, 376, 387, 398, 409, 420, 429, 436, 443, 452, 461, 470, 479, 488, 497, 504, 511, 518, 525, 532, 539, 546, 553, 560 };
-        constexpr int ROOK[] = { 0, 14, 28, 42, 56, 70, 84, 98, 112, 126, 140, 154, 168, 182, 196, 210, 224, 238, 252, 266, 280, 294, 308, 322, 336, 350, 364, 378, 392, 406, 420, 434, 448, 462, 476, 490, 504, 518, 532, 546, 560, 574, 588, 602, 616, 630, 644, 658, 672, 686, 700, 714, 728, 742, 756, 770, 784, 798, 812, 826, 840, 854, 868, 882, 896 };
-        constexpr int QUEEN[] = { 0, 21, 42, 63, 84, 105, 126, 147, 168, 189, 212, 235, 258, 281, 304, 327, 348, 369, 392, 417, 442, 467, 492, 515, 536, 557, 580, 605, 632, 659, 684, 707, 728, 749, 772, 797, 824, 851, 876, 899, 920, 941, 964, 989, 1014, 1039, 1064, 1087, 1108, 1129, 1152, 1175, 1198, 1221, 1244, 1267, 1288, 1309, 1330, 1351, 1372, 1393, 1414, 1435, 1456 };
-        constexpr int KING[] = { 0, 3, 8, 13, 18, 23, 28, 33, 36, 41, 49, 57, 65, 73, 81, 89, 94, 99, 107, 115, 123, 131, 139, 147, 152, 157, 165, 173, 181, 189, 197, 205, 210, 215, 223, 231, 239, 247, 255, 263, 268, 273, 281, 289, 297, 305, 313, 321, 326, 331, 339, 347, 355, 363, 371, 379, 384, 387, 392, 397, 402, 407, 412, 417, 420 };
-
-    }
-
-    namespace PieceOffsets {
-
-        constexpr int PAWN = 0;
-        constexpr int KNIGHT = PAWN + 6 * SquareThreatCounts::PAWN;            // pawn can have threats to 6 different pieces (own pawn, own knight, own rook, opp pawn, opp knight, opp rook)
-        constexpr int BISHOP = KNIGHT + 12 * SquareThreatCounts::KNIGHT[64];   // all 12 pieces possible
-        constexpr int ROOK = BISHOP + 10 * SquareThreatCounts::BISHOP[64];     // queens excluded
-        constexpr int QUEEN = ROOK + 10 * SquareThreatCounts::ROOK[64];        // queens excluded
-        constexpr int KING = QUEEN + 12 * SquareThreatCounts::QUEEN[64];       // all 12 pieces possible
-        constexpr int END = KING + 8 * SquareThreatCounts::KING[64];           // queen and king skipped
-        constexpr int TOTAL = 2 * END;
-
-    }
-
-    constexpr int MAX = std::numeric_limits<int>::max();
-
-    int localThreatIndex(Square to, Bitboard attackedByFrom);
-    Bitboard mirrorBitboard(Bitboard bitboard);
     
-    void addThreatFeatures(Board* board, Color side, FeatureList& features);
+    template<Color side>
+    void addThreatFeatures(Board* board, FeatureList& features);
     void addPieceFeatures(Board* board, Color side, FeatureList& features, const uint8_t* KING_BUCKET_LAYOUT);
     
-    int getPieceFeature(Piece piece, Square relativeSquare, Color relativeColor, uint8_t kingBucket);
-    int getThreatFeature(Piece piece, Square from, Square to, Piece target, Color relativeSide, bool enemy);
-
     void initialise();
 
     template<Color side>
-    int lookupThreatFeature(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
-
-    int getPawnThreatFeature(Square from, Square to, Piece target, Color relativeSide, bool enemy);
-    int getKnightThreatFeature(Square from, Square to, Piece target, Color relativeSide);
-    int getBishopThreatFeature(Square from, Square to, Piece target, Color relativeSide);
-    int getRookThreatFeature(Square from, Square to, Piece target, Color relativeSide);
-    int getQueenThreatFeature(Square from, Square to, Piece target, Color relativeSide);
-    int getKingThreatFeature(Square from, Square to, Piece target, Color relativeSide);
+    int getThreatFeature(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
+    int getPieceFeature(Piece piece, Square relativeSquare, Color relativeColor, uint8_t kingBucket);
 
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.20";
+constexpr auto VERSION = "7.0.21";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Replaces one big feature lookup table with three small ones, the same way that Stockfish currently does feature lookups.
The implementation in stockfish is the result of much optimisation work, with @anematode, @sscg13, @cj5716, @xu-shawn, @aliceroselia and @rn5f107s2 contributing to the current status quo.

VSTC
```
Elo   | 3.48 +- 2.21 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 25886 W: 6555 L: 6296 D: 13035
Penta | [136, 2830, 6793, 3007, 177]
https://furybench.com/test/3716/
```

Bench: 1829595