### PR TITLE
Fix moveSearchCount calculation for best moves

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.23";
+constexpr auto VERSION = "7.0.24";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | -0.16 +- 1.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.69 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 74968 W: 18149 L: 18183 D: 38636
Penta | [105, 8644, 20015, 8620, 100]
https://furybench.com/test/3763/
```

Bench: 1884473