### PR TITLE
Use first-ply continuation history in futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -943,6 +943,8 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
 
                 // Futility pruning
                 int fpValue = eval + fpBase + fpFactor * lmrDepth / 100 + pvNode * (fpPvNode + fpPvNodeBadCapture * !bestMove);
+                if ((stack - 1)->movedPiece != Piece::NONE)
+                    fpValue += (stack - 1)->contHist[2 * 64 * board->pieces[move.origin()] + 2 * move.target() + board->stm] / 500;
                 if (!capture && lmrDepth < fpDepth && fpValue <= alpha) {
                     movegen.skipQuietMoves();
                 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.24";
+constexpr auto VERSION = "7.0.25";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.87 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 55234 W: 13675 L: 13377 D: 28182
Penta | [81, 6281, 14605, 6559, 91]
https://furybench.com/test/3842/
```
LTC
```
Elo   | 3.35 +- 2.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 23328 W: 5881 L: 5656 D: 11791
Penta | [3, 2374, 6686, 2597, 4]
https://furybench.com/test/3849/
```

Bench: 1744056