### PR TITLE
Allow IIR when in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,6 +68,7 @@ TUNE_INT(ttCutOffset, 41, -100, 200);
 TUNE_INT(ttCutFailHighMargin, 121, 0, 200);
 
 TUNE_INT(iirMinDepth, 257, 100, 1000);
+TUNE_INT(iirCheckDepth, 500, 0, 1000);
 TUNE_INT(iirLowTtDepthOffset, 424, 0, 800);
 TUNE_INT(iirReduction, 90, 0, 200);
 
@@ -102,6 +103,7 @@ TUNE_INT(probCutBetaOffset, 201, 1, 500);
 TUNE_INT(probCutDepth, 581, 100, 1000);
 
 TUNE_INT(iir2Reduction, 102, 0, 200);
+TUNE_INT(iir2MinDepth, 257, 100, 1000);
 
 // In-search pruning
 TUNE_INT(earlyLmrImproving, 130, 1, 500);
@@ -760,7 +762,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
     }
 
     // IIR
-    if (!board->checkers && (!ttHit || ttDepth + iirLowTtDepthOffset < depth) && depth >= iirMinDepth)
+    if (depth >= iirMinDepth + iirCheckDepth * !!board->checkers && (!ttHit || ttDepth + iirLowTtDepthOffset < depth))
         depth -= iirReduction;
 
     // Post-LMR depth adjustments
@@ -890,7 +892,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
     }
 
     // IIR 2: Electric boolagoo
-    if (!board->checkers && !ttHit && depth >= iirMinDepth && pvNode)
+    if (!board->checkers && !ttHit && depth >= iir2MinDepth && pvNode)
         depth -= iir2Reduction;
 
     if (stopped || exiting)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.28";
+constexpr auto VERSION = "7.0.29";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.44 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 83792 W: 20666 L: 20319 D: 42807
Penta | [117, 9436, 22442, 9785, 116]
https://furybench.com/test/3993/
```
LTC
```
Elo   | 1.24 +- 1.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.19 (-2.25, 2.89) [0.00, 2.50]
Games | N: 40220 W: 10046 L: 9902 D: 20272
Penta | [7, 4239, 11470, 4391, 3]
https://furybench.com/test/3996/
```
Bench: 1933557