### PR TITLE
Speed up threat accumulator updates on AVX512

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.30";
+constexpr auto VERSION = "7.0.31";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Idea by @anematode

VSTC
```
Elo   | 6.62 +- 3.08 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 2.50]
Games | N: 12288 W: 3077 L: 2843 D: 6368
Penta | [30, 1283, 3307, 1471, 53]
https://furybench.com/test/4063/
```

Bench: 1933557