### PR TITLE
SPSA tune with 4 threads for 7.5k iterations

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -8,43 +8,43 @@
 #include "spsa.h"
 
 // Quiet history
-TUNE_INT(historyBonusQuietBase, 138, 0, 250);
-TUNE_INT(historyBonusQuietFactor, 262, 1, 500);
-TUNE_INT(historyBonusQuietMax, 2124, 1, 4000);
-TUNE_INT(historyMalusQuietBase, 100, 0, 250);
-TUNE_INT(historyMalusQuietFactor, 241, 1, 500);
-TUNE_INT(historyMalusQuietMax, 1482, 1, 3000);
+TUNE_INT(historyBonusQuietBase, 140, 0, 250);
+TUNE_INT(historyBonusQuietFactor, 264, 1, 500);
+TUNE_INT(historyBonusQuietMax, 2150, 1, 4000);
+TUNE_INT(historyMalusQuietBase, 106, 0, 250);
+TUNE_INT(historyMalusQuietFactor, 239, 1, 500);
+TUNE_INT(historyMalusQuietMax, 1520, 1, 3000);
 
 // Continuation history
-TUNE_INT(historyBonusContinuationBase, -73, -200, 0);
-TUNE_INT(historyBonusContinuationFactor, 128, 1, 250);
-TUNE_INT(historyBonusContinuationMax, 2103, 1, 4000);
-TUNE_INT(historyMalusContinuationBase, 96, 0, 200);
-TUNE_INT(historyMalusContinuationFactor, 239, 1, 500);
-TUNE_INT(historyMalusContinuationMax, 813, 1, 1500);
+TUNE_INT(historyBonusContinuationBase, -77, -200, 0);
+TUNE_INT(historyBonusContinuationFactor, 132, 1, 250);
+TUNE_INT(historyBonusContinuationMax, 2035, 1, 4000);
+TUNE_INT(historyMalusContinuationBase, 102, 0, 200);
+TUNE_INT(historyMalusContinuationFactor, 273, 1, 500);
+TUNE_INT(historyMalusContinuationMax, 835, 1, 1500);
 
 // Pawn history
-TUNE_INT(historyBonusPawnBase, 33, -100, 100);
-TUNE_INT(historyBonusPawnFactor, 172, 1, 250);
-TUNE_INT(historyBonusPawnMax, 2059, 1, 4000);
-TUNE_INT(historyMalusPawnBase, 30, -100, 100);
-TUNE_INT(historyMalusPawnFactor, 276, 1, 500);
-TUNE_INT(historyMalusPawnMax, 2104, 1, 4000);
+TUNE_INT(historyBonusPawnBase, 39, -100, 100);
+TUNE_INT(historyBonusPawnFactor, 170, 1, 250);
+TUNE_INT(historyBonusPawnMax, 2070, 1, 4000);
+TUNE_INT(historyMalusPawnBase, 29, -100, 100);
+TUNE_INT(historyMalusPawnFactor, 288, 1, 500);
+TUNE_INT(historyMalusPawnMax, 2148, 1, 4000);
 
 // Capture history
-TUNE_INT(historyBonusCaptureBase, 24, -100, 100);
+TUNE_INT(historyBonusCaptureBase, 14, -100, 100);
 TUNE_INT(historyBonusCaptureFactor, 115, 1, 250);
-TUNE_INT(historyBonusCaptureMax, 1411, 1, 2500);
-TUNE_INT(historyMalusCaptureBase, 94, 0, 200);
-TUNE_INT(historyMalusCaptureFactor, 241, 1, 500);
-TUNE_INT(historyMalusCaptureMax, 1567, 1, 3000);
+TUNE_INT(historyBonusCaptureMax, 1325, 1, 2500);
+TUNE_INT(historyMalusCaptureBase, 97, 0, 200);
+TUNE_INT(historyMalusCaptureFactor, 236, 1, 500);
+TUNE_INT(historyMalusCaptureMax, 1486, 1, 3000);
 
 // Correction history
-TUNE_INT(pawnCorrectionFactor, 6401, 1000, 7500);
-TUNE_INT(nonPawnCorrectionFactor, 6018, 1000, 7500);
-TUNE_INT(minorCorrectionFactor, 3783, 1000, 7500);
-TUNE_INT(majorCorrectionFactor, 2693, 1000, 7500);
-TUNE_INT(continuationCorrectionFactor, 5801, 1000, 7500);
+TUNE_INT(pawnCorrectionFactor, 6429, 1000, 7500);
+TUNE_INT(nonPawnCorrectionFactor, 5827, 1000, 7500);
+TUNE_INT(minorCorrectionFactor, 4178, 1000, 7500);
+TUNE_INT(majorCorrectionFactor, 2295, 1000, 7500);
+TUNE_INT(continuationCorrectionFactor, 5762, 1000, 7500);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -41,118 +41,118 @@ TUNE_INT_DISABLED(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT_DISABLED(aspirationWindowDelta, 14, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowDeltaBase, 10, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowMaxFailHighs, 3, 1, 10);
-TUNE_FLOAT(aspirationWindowDeltaFactor, 1.5804938062670641f, 1.0f, 3.0f);
-TUNE_INT(aspirationWindowDeltaDivisor, 13032, 7500, 17500);
+TUNE_FLOAT(aspirationWindowDeltaFactor, 1.6824316885254968f, 1.0f, 3.0f);
+TUNE_INT(aspirationWindowDeltaDivisor, 13052, 7500, 17500);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.11179712725778632f, -1.0f, 1.0f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.130045083882443f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.2037031842229747f, -1.0f, 1.0f);
-TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.1810657117079457f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 1.1606592351964504f, 0.0f, 2.0f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.909469676444663f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.16746504757915998f, -1.0f, 1.0f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 3.015294386647946f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.18494142853230522f, -1.0f, 1.0f);
+TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.1771025906820594f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 1.1156812184145881f, 0.0f, 2.0f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.9348373864040274f, 2.0f, 4.0f);
 
-TUNE_FLOAT(lmpMarginWorseningBase, 1.8639912522039657f, 0.0f, 3.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.4122803433523727f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.5666560928932445f, 0.0f, 4.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 2.741810009419904f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 0.7984448433062328f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 2.0331756453343477f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.976556330827873f, 0.0f, 3.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.4409114850475385f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.539323819754223f, 0.0f, 4.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 2.837411229046308f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 0.8604609467433942f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 1.9566999909630995f, 1.0f, 3.0f);
 
 // Search values
-TUNE_INT(qsFutilityOffset, 81, 1, 125);
-TUNE_INT(qsSeeMargin, -71, -200, 50);
+TUNE_INT(qsFutilityOffset, 83, 1, 125);
+TUNE_INT(qsSeeMargin, -68, -200, 50);
 
 // Pre-search pruning
-TUNE_INT(ttCutOffset, 41, 0, 100);
-TUNE_INT(ttCutFailHighMargin, 121, 0, 240);
+TUNE_INT(ttCutOffset, 43, 0, 100);
+TUNE_INT(ttCutFailHighMargin, 123, 0, 240);
 
 TUNE_INT(iirMinDepth, 257, 100, 500);
-TUNE_INT(iirCheckDepth, 500, 0, 1000);
-TUNE_INT(iirLowTtDepthOffset, 424, 0, 850);
+TUNE_INT(iirCheckDepth, 509, 0, 1000);
+TUNE_INT(iirLowTtDepthOffset, 437, 0, 850);
 TUNE_INT(iirReduction, 90, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -102, -200, -1);
-TUNE_INT(staticHistoryMin, -149, -500, -1);
-TUNE_INT(staticHistoryMax, 278, 1, 500);
-TUNE_INT(staticHistoryTempo, 30, 1, 60);
+TUNE_INT(staticHistoryFactor, -101, -200, -1);
+TUNE_INT(staticHistoryMin, -172, -500, -1);
+TUNE_INT(staticHistoryMax, 286, 1, 500);
+TUNE_INT(staticHistoryTempo, 27, 1, 60);
 
-TUNE_INT(rfpDepth, 1400, 200, 2000);
-TUNE_INT(rfpBase, 11, -100, 100);
+TUNE_INT(rfpDepth, 1450, 200, 2000);
+TUNE_INT(rfpBase, 17, -100, 100);
 TUNE_INT(rfpFactorLinear, 31, 1, 60);
-TUNE_INT(rfpFactorQuadratic, 655, 1, 1200);
-TUNE_INT(rfpImprovingOffset, 100, 1, 200);
+TUNE_INT(rfpFactorQuadratic, 700, 1, 1200);
+TUNE_INT(rfpImprovingOffset, 101, 1, 200);
 TUNE_INT(rfpBaseCheck, -5, -100, 100);
-TUNE_INT(rfpFactorLinearCheck, 40, 1, 80);
-TUNE_INT(rfpFactorQuadraticCheck, 546, 1, 1200);
-TUNE_INT(rfpImprovingOffsetCheck, 100, 1, 200);
+TUNE_INT(rfpFactorLinearCheck, 39, 1, 80);
+TUNE_INT(rfpFactorQuadraticCheck, 507, 1, 1200);
+TUNE_INT(rfpImprovingOffsetCheck, 98, 1, 200);
 
-TUNE_INT(razoringDepth, 493, 100, 1000);
-TUNE_INT(razoringFactor, 276, 1, 500);
+TUNE_INT(razoringDepth, 528, 100, 1000);
+TUNE_INT(razoringFactor, 267, 1, 500);
 
-TUNE_INT(nmpMinDepth, 334, 0, 700);
-TUNE_INT(nmpRedBase, 353, 100, 700);
-TUNE_INT(nmpDepthDiv, 263, 100, 500);
-TUNE_INT(nmpMin, 372, 100, 700);
-TUNE_INT(nmpDivisor, 223, 10, 500);
+TUNE_INT(nmpMinDepth, 355, 0, 700);
+TUNE_INT(nmpRedBase, 365, 100, 700);
+TUNE_INT(nmpDepthDiv, 246, 100, 500);
+TUNE_INT(nmpMin, 380, 100, 700);
+TUNE_INT(nmpDivisor, 211, 10, 500);
 TUNE_INT_DISABLED(nmpEvalDepth, 7, 1, 100);
-TUNE_INT(nmpEvalBase, 158, 50, 350);
+TUNE_INT(nmpEvalBase, 164, 50, 350);
 
-TUNE_INT(probcutReduction, 437, 0, 800);
-TUNE_INT(probCutBetaOffset, 201, 1, 400);
-TUNE_INT(probCutDepth, 581, 100, 1000);
+TUNE_INT(probcutReduction, 409, 0, 800);
+TUNE_INT(probCutBetaOffset, 206, 1, 400);
+TUNE_INT(probCutDepth, 560, 100, 1000);
 
-TUNE_INT(iir2Reduction, 102, 0, 200);
-TUNE_INT(iir2MinDepth, 257, 100, 500);
+TUNE_INT(iir2Reduction, 101, 0, 200);
+TUNE_INT(iir2MinDepth, 266, 100, 500);
 
 // In-search pruning
-TUNE_INT(earlyLmrImproving, 130, 1, 260);
+TUNE_INT(earlyLmrImproving, 123, 1, 260);
 
-TUNE_INT(earlyLmrHistoryFactorQuiet, 15941, 10000, 20000);
-TUNE_INT(earlyLmrHistoryFactorCapture, 14387, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorQuiet, 15842, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorCapture, 14293, 10000, 20000);
 
-TUNE_INT(fpDepth, 1078, 100, 2000);
-TUNE_INT(fpBase, 306, 1, 600);
+TUNE_INT(fpDepth, 1097, 100, 2000);
+TUNE_INT(fpBase, 295, 1, 600);
 TUNE_INT(fpFactor, 70, 1, 150);
-TUNE_INT(fpPvNode, 39, 1, 80);
-TUNE_INT(fpPvNodeBadCapture, 118, 1, 250);
+TUNE_INT(fpPvNode, 36, 1, 80);
+TUNE_INT(fpPvNodeBadCapture, 117, 1, 250);
 
-TUNE_INT(fpCaptDepth, 763, 100, 1500);
-TUNE_INT(fpCaptBase, 415, 150, 800);
-TUNE_INT(fpCaptFactor, 419, 100, 800);
+TUNE_INT(fpCaptDepth, 846, 100, 1500);
+TUNE_INT(fpCaptBase, 432, 150, 800);
+TUNE_INT(fpCaptFactor, 397, 100, 800);
 
-TUNE_INT(historyPruningDepth, 480, 100, 1000);
-TUNE_INT(historyPruningFactorCapture, -2169, -4000, -1);
-TUNE_INT(historyPruningFactorQuiet, -6430, -12000, -1);
+TUNE_INT(historyPruningDepth, 457, 100, 1000);
+TUNE_INT(historyPruningFactorCapture, -2170, -4000, -1);
+TUNE_INT(historyPruningFactorQuiet, -6724, -12000, -1);
 
-TUNE_INT(extensionMinDepth, 660, 0, 1200);
-TUNE_INT(extensionTtDepthOffset, 455, 0, 800);
-TUNE_INT(doubleExtensionDepthIncreaseFactor, 93, 0, 200);
+TUNE_INT(extensionMinDepth, 620, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 470, 0, 800);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 79, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
-TUNE_INT(doubleExtensionDepthIncrease, 1063, 200, 2000);
+TUNE_INT(doubleExtensionDepthIncrease, 1002, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT(lmrMinDepth, 285, 100, 600);
+TUNE_INT(lmrMinDepth, 307, 100, 600);
 
-TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 150, 0, 300);
-TUNE_INT(lmrReductionOffsetImportantCapture, 5, 0, 100);
-TUNE_INT(lmrCheckQuietOrNormalCapture, 115, 0, 230);
-TUNE_INT(lmrCheckImportantCapture, 56, 0, 120);
-TUNE_INT(lmrTtPvQuietOrNormalCapture, 206, 0, 400);
-TUNE_INT(lmrTtPvImportantCapture, 206, 0, 400);
-TUNE_INT(lmrCutnode, 264, 0, 500);
+TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 145, 0, 300);
+TUNE_INT(lmrReductionOffsetImportantCapture, 7, 0, 100);
+TUNE_INT(lmrCheckQuietOrNormalCapture, 108, 0, 230);
+TUNE_INT(lmrCheckImportantCapture, 58, 0, 120);
+TUNE_INT(lmrTtPvQuietOrNormalCapture, 191, 0, 400);
+TUNE_INT(lmrTtPvImportantCapture, 197, 0, 400);
+TUNE_INT(lmrCutnode, 267, 0, 500);
 TUNE_INT(lmrTtpvFaillowQuietOrNormalCapture, 46, 0, 100);
-TUNE_INT(lmrTtpvFaillowImportantCapture, 85, 0, 200);
-TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 142842, 100000, 200000);
-TUNE_INT(lmrCorrectionDivisorImportantCapture, 145933, 100000, 200000);
-TUNE_INT(lmrQuietHistoryDivisor, 29208, 10000, 60000);
-TUNE_INT(lmrHistoryFactorCapture, 3059928, 2500000, 4000000);
-TUNE_INT(lmrHistoryFactorImportantCapture, 2993600, 2500000, 4000000);
-TUNE_INT(lmrImportantBadCaptureOffset, 115, 0, 230);
-TUNE_INT(lmrImportantCaptureFactor, 33, 0, 60);
-TUNE_INT(lmrQuietPvNodeOffset, 17, 0, 50);
+TUNE_INT(lmrTtpvFaillowImportantCapture, 87, 0, 200);
+TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 140128, 100000, 200000);
+TUNE_INT(lmrCorrectionDivisorImportantCapture, 146432, 100000, 200000);
+TUNE_INT(lmrQuietHistoryDivisor, 28908, 10000, 60000);
+TUNE_INT(lmrHistoryFactorCapture, 3122217, 2500000, 4000000);
+TUNE_INT(lmrHistoryFactorImportantCapture, 3006170, 2500000, 4000000);
+TUNE_INT(lmrImportantBadCaptureOffset, 110, 0, 230);
+TUNE_INT(lmrImportantCaptureFactor, 31, 0, 60);
+TUNE_INT(lmrQuietPvNodeOffset, 19, 0, 50);
 TUNE_INT(lmrQuietImproving, 58, 0, 100);
 
 inline int lmrReductionOffset(bool importantCapture) { return importantCapture ? lmrReductionOffsetImportantCapture : lmrReductionOffsetQuietOrNormalCapture; };
@@ -162,28 +162,28 @@ inline int lmrTtpvFaillow(bool importantCapture) { return importantCapture ? lmr
 inline int lmrCaptureHistoryDivisor(bool importantCapture) { return importantCapture ? lmrHistoryFactorImportantCapture : lmrHistoryFactorCapture; };
 inline int lmrCorrectionDivisor(bool importantCapture) { return importantCapture ? lmrCorrectionDivisorImportantCapture : lmrCorrectionDivisorQuietOrNormalCapture; };
 
-TUNE_INT(postlmrOppWorseningThreshold, 257, 150, 450);
-TUNE_INT(postlmrOppWorseningReduction, 142, 0, 200);
+TUNE_INT(postlmrOppWorseningThreshold, 240, 150, 450);
+TUNE_INT(postlmrOppWorseningReduction, 145, 0, 200);
 
-TUNE_INT(lmrPvNodeExtension, 107, 0, 200);
+TUNE_INT(lmrPvNodeExtension, 109, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
-TUNE_INT(lmrDeeperWeight, 106, 0, 200);
-TUNE_INT(lmrShallowerWeight, 110, 0, 200);
-TUNE_INT(lmrResearchSkipDepthOffset, 408, 0, 800);
+TUNE_INT(lmrDeeperWeight, 112, 0, 200);
+TUNE_INT(lmrShallowerWeight, 111, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 432, 0, 800);
 
-TUNE_INT(lmrPassBonusBase, -260, -500, 0);
-TUNE_INT(lmrPassBonusFactor, 148, 1, 300);
-TUNE_INT(lmrPassBonusMax, 1044, 0, 2000);
+TUNE_INT(lmrPassBonusBase, -293, -500, 0);
+TUNE_INT(lmrPassBonusFactor, 154, 1, 300);
+TUNE_INT(lmrPassBonusMax, 1012, 0, 2000);
 
-TUNE_INT(historyDepthBetaOffset, 210, 1, 400);
+TUNE_INT(historyDepthBetaOffset, 218, 1, 400);
 
-TUNE_INT(lowDepthPvDepthReductionMin, 446, 0, 800);
-TUNE_INT(lowDepthPvDepthReductionMax, 1150, 0, 2000);
-TUNE_INT(lowDepthPvDepthReductionWeight, 117, 0, 200);
+TUNE_INT(lowDepthPvDepthReductionMin, 423, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1095, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 110, 0, 200);
 
-TUNE_INT(correctionHistoryFactor, 110, 0, 300);
-TUNE_INT(correctionHistoryFactorMulticut, 162, 0, 300);
+TUNE_INT(correctionHistoryFactor, 120, 0, 300);
+TUNE_INT(correctionHistoryFactorMulticut, 164, 0, 300);
 
 int REDUCTIONS[3][MAX_PLY][MAX_MOVES];
 int LMP_MARGIN[MAX_PLY][2];

--- a/src/spsa.h
+++ b/src/spsa.h
@@ -92,7 +92,7 @@ public:
 
 };
 
-#define TUNE_ENABLED true
+#define TUNE_ENABLED false
 
 // Some fancy macro stuff to call the tune() methods inline from anywhere
 #define STRINGIFY(x) #x

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -2,8 +2,8 @@
 #include "move.h"
 #include "spsa.h"
 
-TUNE_INT(ttReplaceTtpvBonus, 214, 0, 400);
-TUNE_INT(ttReplaceOffset, 451, 0, 800);
+TUNE_INT(ttReplaceTtpvBonus, 225, 0, 400);
+TUNE_INT(ttReplaceOffset, 443, 0, 800);
 
 void TTEntry::update(Hash _hash, Move _bestMove, Depth _depth, Eval _eval, Eval _value, uint8_t _rule50, bool wasPv, int _flags) {
     // Update bestMove if it exists

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.31";
+constexpr auto VERSION = "7.0.32";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Roughly neutral on 1 thread:
```
Elo   | 1.18 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.45 (-2.25, 2.89) [0.00, 2.50]
Games | N: 61594 W: 15104 L: 14895 D: 31595
Penta | [83, 7078, 16268, 7283, 85]
https://furybench.com/test/4065/
```
```
Elo   | -0.45 +- 2.37 (95%)
SPRT  | 80.0+0.80s Threads=1 Hash=128MB
LLR   | -0.79 (-2.25, 2.89) [0.00, 2.50]
Games | N: 16830 W: 4174 L: 4196 D: 8460
Penta | [1, 1727, 4980, 1707, 0]
https://furybench.com/test/4066/
```

Gains on 4 threads:
```
Elo   | 3.51 +- 2.08 (95%)
SPRT  | 40.0+0.40s Threads=4 Hash=256MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 21372 W: 5471 L: 5255 D: 10646
Penta | [1, 2025, 6418, 2241, 1]
https://furybench.com/test/4050/
```

Bench: 2081677