### PR TITLE
Decrease size of DirtyThreat struct

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -119,7 +119,7 @@ void NNUE::updateThreat(Piece piece, Piece attackedPiece, Square square, Square 
     assert(attackedPiece != Piece::NONE);
 
     Accumulator* acc = &accumulatorStack[currentAccumulator];
-    acc->dirtyThreats[acc->numDirtyThreats++] = { piece, attackedPiece, square, attackedSquare, pieceColor, attackedColor, add };
+    acc->dirtyThreats[acc->numDirtyThreats++] = DirtyThreat(piece, pieceColor, attackedPiece, attackedColor, square, attackedSquare, add);
 }
 
 void NNUE::incrementAccumulator() {
@@ -242,10 +242,11 @@ void NNUE::incrementallyUpdateThreatFeatures(Accumulator* inputAcc, Accumulator*
 
     for (int dp = 0; dp < outputAcc->numDirtyThreats; dp++) {
         DirtyThreat& dt = outputAcc->dirtyThreats[dp];
+        bool add = dt.attackedSquare >> 7;
 
-        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.pieceColor, dt.square, dt.attackedSquare, dt.attackedPiece, dt.attackedColor, kingBucket->mirrored);
+        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare & 0b111111, kingBucket->mirrored);
         if (featureIndex < ThreatInputs::FEATURE_COUNT) {
-            (dt.add ? addFeatures : subFeatures).add(featureIndex);
+            (add ? addFeatures : subFeatures).add(featureIndex);
         }
     }
 

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -51,14 +51,23 @@ struct DirtyPiece {
 };
 
 struct DirtyThreat {
-  Piece piece;
-  Piece attackedPiece;
+  uint8_t piece;
+  uint8_t attackedPiece;
   Square square;
-  Square attackedSquare;
-  Color pieceColor;
-  Color attackedColor;
-  bool add;
+  uint8_t attackedSquare;
+
+  DirtyThreat() = default;
+
+  DirtyThreat(Piece _piece, Color _pieceColor, Piece _attackedPiece, Color _attackedPieceColor, Square _square, Square _attackedSquare, bool _add) {
+    piece = static_cast<uint8_t>(_piece | (_pieceColor << 3));
+    attackedPiece = static_cast<uint8_t>(_attackedPiece | (_attackedPieceColor << 3));
+    square = _square;
+    attackedSquare = static_cast<uint8_t>(_attackedSquare | (_add << 7));
+  }
+
 };
+
+static_assert(sizeof(DirtyThreat) == 4);
 
 struct KingBucketInfo {
   uint8_t bucket;

--- a/src/threat-inputs.h
+++ b/src/threat-inputs.h
@@ -23,7 +23,7 @@ namespace ThreatInputs {
     void initialise();
 
     template<Color side>
-    int getThreatFeature(Piece attackingPiece, uint8_t attackingColor, Square attackingSquare, Square attackedSquare, Piece attackedPiece, uint8_t attackedColor, bool mirrored);
+    int getThreatFeature(uint8_t attackingPiece, uint8_t attackedPiece, Square attackingSquare, Square attackedSquare, bool mirrored);
     int getPieceFeature(Piece piece, Square relativeSquare, Color relativeColor, uint8_t kingBucket);
 
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.33";
+constexpr auto VERSION = "7.0.34";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
VSTC
```
Elo   | 1.44 +- 1.57 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=16MB
LLR   | 1.59 (-2.25, 2.89) [0.00, 2.50]
Games | N: 50516 W: 12771 L: 12562 D: 25183
Penta | [264, 5607, 13356, 5718, 313]
https://furybench.com/test/4079/
```

Bench: 2081677