### PR TITLE
Also allow normal futility pruning for bad captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -937,7 +937,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
 
             // Futility pruning
             int fpValue = eval + fpBase + fpFactor * lmrDepth / 100 + pvNode * (fpPvNode + fpPvNodeBadCapture * !bestMove);
-            if ((stack - 1)->movedPiece != Piece::NONE)
+            if (!capture && (stack - 1)->movedPiece != Piece::NONE)
                 fpValue += (stack - 1)->contHist[2 * 64 * board->pieces[move.origin()] + 2 * move.target() + board->stm] / 500;
             if (lmrDepth < fpDepth && fpValue <= alpha) {
                 if (!capture)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.35";
+constexpr auto VERSION = "7.0.36";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.36 +- 1.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 93508 W: 23058 L: 22691 D: 47759
Penta | [126, 10757, 24625, 11116, 130]
https://furybench.com/test/4083/
```
LTC
```
Elo   | 2.27 +- 1.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 39264 W: 9884 L: 9628 D: 19752
Penta | [6, 4122, 11117, 4384, 3]
https://furybench.com/test/4105/
```

Bench: 2194974