### PR TITLE
Speed up accumulator calculation by changing the DirtyPiece layout

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -307,8 +307,6 @@ void Board::addPiece(Piece piece, Color pieceColor, Square square, NNUE* nnue) {
 
     pieces[square] = piece;
 
-    nnue->addPiece(square, piece, pieceColor);
-
     updatePieceThreats<true>(piece, pieceColor, square, nnue);
     updatePieceHash(piece, pieceColor, Zobrist::PIECE_SQUARES[pieceColor][piece][square]);
     updatePieceCastling(piece, pieceColor, square);
@@ -323,8 +321,6 @@ void Board::removePiece(Piece piece, Color pieceColor, Square square, NNUE* nnue
 
     pieces[square] = Piece::NONE;
 
-    nnue->removePiece(square, piece, pieceColor);
-
     updatePieceThreats<false>(piece, pieceColor, square, nnue);
     updatePieceHash(piece, pieceColor, Zobrist::PIECE_SQUARES[pieceColor][piece][square]);
     updatePieceCastling(piece, pieceColor, square);
@@ -333,8 +329,6 @@ void Board::removePiece(Piece piece, Color pieceColor, Square square, NNUE* nnue
 void Board::movePiece(Piece piece, Color pieceColor, Square origin, Square target, NNUE* nnue) {
     assert(pieces[origin] != Piece::NONE);
     assert(pieces[target] == Piece::NONE);
-
-    nnue->movePiece(origin, target, piece, pieceColor);
     
     Bitboard fromTo = bitboard(origin) ^ bitboard(target);
     updatePieceThreats<false>(piece, pieceColor, origin, nnue, fromTo);
@@ -362,7 +356,6 @@ void Board::swapPiece(Piece piece, Color pieceColor, Square square, NNUE* nnue) 
     byPiece[oldPiece] ^= squareBB;
     pieces[square] = Piece::NONE;
 
-    nnue->removePiece(square, oldPiece, oldPieceColor);
     updatePieceThreats<false, false>(oldPiece, oldPieceColor, square, nnue);
     updatePieceHash(oldPiece, oldPieceColor, Zobrist::PIECE_SQUARES[oldPieceColor][oldPiece][square]);
     updatePieceCastling(oldPiece, oldPieceColor, square);
@@ -372,7 +365,6 @@ void Board::swapPiece(Piece piece, Color pieceColor, Square square, NNUE* nnue) 
     byPiece[piece] ^= squareBB;
     pieces[square] = piece;
 
-    nnue->addPiece(square, piece, pieceColor);
     updatePieceThreats<true, false>(piece, pieceColor, square, nnue);
     updatePieceHash(piece, pieceColor, Zobrist::PIECE_SQUARES[pieceColor][piece][square]);
     updatePieceCastling(piece, pieceColor, square);
@@ -401,17 +393,30 @@ void Board::doMove(Move move, Hash newHash, NNUE* nnue) {
     Piece piece = pieces[origin];
     Piece promotionPiece = Piece::NONE;
 
+    DirtyPiece dirtyPiece;
+    dirtyPiece.piece = piece;
+    dirtyPiece.pieceColor = stm;
+    dirtyPiece.origin = origin;
+    dirtyPiece.target = target;
+    dirtyPiece.addSquare = dirtyPiece.removeSquare = NO_SQUARE;
+
     switch (move.type()) {
     case MoveType::PROMOTION:
 
         if (capturedPiece != Piece::NONE) {
             removePiece(capturedPiece, flip(stm), captureTarget, nnue);
+            dirtyPiece.removePiece = capturedPiece;
+            dirtyPiece.removeSquare = captureTarget;
         }
 
         removePiece(piece, stm, origin, nnue);
         rule50_ply = 0;
         promotionPiece = move.promotionPiece();
         addPiece(promotionPiece, stm, target, nnue);
+
+        dirtyPiece.target = NO_SQUARE;
+        dirtyPiece.addSquare = target;
+        dirtyPiece.addPiece = promotionPiece;
 
         break;
 
@@ -426,6 +431,10 @@ void Board::doMove(Move move, Hash newHash, NNUE* nnue) {
         removePiece(Piece::ROOK, stm, rookOrigin, nnue);
         addPiece(Piece::KING, stm, kingTarget, nnue);
         addPiece(Piece::ROOK, stm, rookTarget, nnue);
+
+        dirtyPiece.target = kingTarget;
+        dirtyPiece.removeSquare = rookOrigin;
+        dirtyPiece.addSquare = rookTarget;
 
         capturedPiece = Piece::NONE;
     }
@@ -442,6 +451,9 @@ void Board::doMove(Move move, Hash newHash, NNUE* nnue) {
 
         removePiece(Piece::PAWN, flip(stm), captureTarget, nnue);
 
+        dirtyPiece.removePiece = capturedPiece;
+        dirtyPiece.removeSquare = captureTarget;
+
         break;
 
     default: // Normal moves
@@ -451,6 +463,9 @@ void Board::doMove(Move move, Hash newHash, NNUE* nnue) {
             removePiece(piece, stm, origin, nnue);
             swapPiece(piece, stm, target, nnue);
             rule50_ply = 0;
+
+            dirtyPiece.removePiece = capturedPiece;
+            dirtyPiece.removeSquare = captureTarget;
         } else {
             movePiece(piece, stm, origin, target, nnue);
         }
@@ -490,7 +505,7 @@ void Board::doMove(Move move, Hash newHash, NNUE* nnue) {
     stm = flip(stm);
     lastMove = move;
 
-    nnue->finalizeMove(this);
+    nnue->finalizeMove(this, dirtyPiece);
 
     calculateThreats();
 }

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -43,13 +43,6 @@ constexpr int INT8_PER_INT32 = sizeof(int32_t) / sizeof(int8_t);
 
 constexpr int L1_ITERATIONS = L1_SIZE / I16_VEC_SIZE;
 
-struct DirtyPiece {
-  Square origin;
-  Square target;
-  Piece piece;
-  Color pieceColor;
-};
-
 struct DirtyThreat {
   uint8_t piece;
   uint8_t attackedPiece;
@@ -85,8 +78,7 @@ struct Accumulator {
   alignas(ALIGNMENT) int16_t threatState[2][L1_SIZE];
   alignas(ALIGNMENT) int16_t pieceState[2][L1_SIZE];
 
-  DirtyPiece dirtyPieces[4];
-  int numDirtyPieces;
+  DirtyPiece dirtyPiece;
   DirtyThreat dirtyThreats[256];
   int numDirtyThreats;
 
@@ -128,14 +120,11 @@ public:
 
   FinnyEntry finnyTable[2][KING_BUCKETS];
 
-  void addPiece(Square square, Piece piece, Color pieceColor);
-  void removePiece(Square square, Piece piece, Color pieceColor);
-  void movePiece(Square origin, Square target, Piece piece, Color pieceColor);
   void updateThreat(Piece piece, Piece attackedPiece, Square square, Square attackedSquare, Color pieceColor, Color attackedColor, bool add);
 
   void incrementAccumulator();
   void decrementAccumulator();
-  void finalizeMove(Board* board);
+  void finalizeMove(Board* board, DirtyPiece dirtyPiece);
 
   void reset(Board* board);
   template<Color side>

--- a/src/types.h
+++ b/src/types.h
@@ -288,3 +288,20 @@ struct SearchStack {
     int16_t* contHist;
     int16_t* contCorrHist;
 };
+
+struct DirtyPiece {
+    // Base data for a standard move
+    Piece piece;
+    Color pieceColor;
+    Square origin, target; // target is empty in case of promotion
+
+    // For captures - color of the piece is the opposite of pieceColor
+    // In case of castling, contains the origin square of the rook
+    Piece removePiece;
+    Square removeSquare;
+
+    // For promotions - color of the piece is the same as pieceColor
+    // In case of castling, contains the target square of the rook
+    Piece addPiece;
+    Square addSquare;
+};

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.36";
+constexpr auto VERSION = "7.0.37";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Simplified SF-style DirtyPiece setup

VSTC
```
Elo   | 7.71 +- 3.46 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 2.50]
Games | N: 10412 W: 2691 L: 2460 D: 5261
Penta | [49, 1072, 2748, 1273, 64]
https://furybench.com/test/4128/
```

Bench: 2194974