### PR TITLE
Make use of ttValue in qsearch when in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -472,7 +472,7 @@ Eval Worker::qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta) {
         stack->staticEval = bestValue = unadjustedEval = futilityValue = -EVAL_INFINITE;
 
         if (ttValue != EVAL_NONE && std::abs(ttValue) < EVAL_TBWIN_IN_MAX_PLY && ((ttFlag == TT_UPPERBOUND && ttValue < bestValue) || (ttFlag == TT_LOWERBOUND && ttValue > bestValue) || (ttFlag == TT_EXACTBOUND)))
-            bestValue = ttValue;
+            bestValue = futilityValue = ttValue;
 
         goto movesLoopQsearch;
     }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.37";
+constexpr auto VERSION = "7.0.38";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.16 +- 0.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 125726 W: 30885 L: 30465 D: 64376
Penta | [153, 14315, 33546, 14657, 192]
```
https://furybench.com/test/4171/

Bench: 2070355