### PR TITLE
Increase the amount of static eval history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,10 +72,10 @@ TUNE_INT(iirCheckDepth, 509, 0, 1000);
 TUNE_INT(iirLowTtDepthOffset, 437, 0, 850);
 TUNE_INT(iirReduction, 90, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -101, -200, -1);
-TUNE_INT(staticHistoryMin, -172, -500, -1);
-TUNE_INT(staticHistoryMax, 286, 1, 500);
-TUNE_INT(staticHistoryTempo, 27, 1, 60);
+TUNE_INT(staticHistoryFactor, -250, -200, -1);
+TUNE_INT(staticHistoryMin, -430, -500, -1);
+TUNE_INT(staticHistoryMax, 715, 1, 500);
+TUNE_INT(staticHistoryTempo, 170, 1, 60);
 
 TUNE_INT(rfpDepthLimit, 1450, 200, 2000);
 TUNE_INT(rfpBase, 17, -100, 100);

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.41";
+constexpr auto VERSION = "7.0.42";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 1.12 +- 0.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 145094 W: 35866 L: 35399 D: 73829
Penta | [294, 16873, 37761, 17310, 309]
```
https://furybench.com/test/4301/

Bench: 2161353