### PR TITLE
Fix TT hash calculation with regard to fifty-move rule zobrists

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -785,7 +785,7 @@ bool Board::givesCheck(Move move) {
     }
 }
 
-Hash Board::hashAfter(Move move) {
+std::pair<Hash, Hash> Board::hashAfter(Move move) {
     Hash hash = hashes.hash ^ Zobrist::STM_BLACK;
 
     Square origin = move.origin();
@@ -867,7 +867,9 @@ Hash Board::hashAfter(Move move) {
         hash ^= Zobrist::PIECE_SQUARES[stm][piece][target] ^ Zobrist::PIECE_SQUARES[stm][promotionPiece][target];
     }
 
-    return hash;
+    uint8_t newFmr = isCapture(move) || piece == Piece::PAWN ? 0 : rule50_ply + 1;
+    Hash fmrHash = hash ^ Zobrist::FMR[newFmr / Zobrist::FMR_GRANULARITY];
+    return std::make_pair(hash, fmrHash);
 }
 
 void Board::updateSliderPins(Color side) {

--- a/src/board.h
+++ b/src/board.h
@@ -120,7 +120,7 @@ struct Board {
         return castlingSquares[2 * side + direction];
     }
 
-    Hash hashAfter(Move move);
+    std::pair<Hash, Hash> hashAfter(Move move);
 
     void updateSliderPins(Color side);
 

--- a/src/datagen.cpp
+++ b/src/datagen.cpp
@@ -51,7 +51,7 @@ bool playRandomMoves(Board& board, Worker* thread, int remainingMoves) {
         }
     }
     Board boardCopy = board;
-    boardCopy.doMove(move, boardCopy.hashAfter(move), &thread->nnue);
+    boardCopy.doMove(move, boardCopy.hashAfter(move).first, &thread->nnue);
 
     return playRandomMoves(boardCopy, thread, remainingMoves - 1);
 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -5,7 +5,6 @@
 TUNE_INT(ttReplaceTtpvBonus, 225, 0, 400);
 TUNE_INT(ttReplaceOffset, 443, 0, 800);
 
-__attribute__((no_sanitize("thread")))
 void TTEntry::update(Hash _hash, Move _bestMove, Depth _depth, Eval _eval, Eval _value, uint8_t _rule50, bool wasPv, int _flags) {
     // Update bestMove if it exists
     // Or clear it for a different position
@@ -22,9 +21,8 @@ void TTEntry::update(Hash _hash, Move _bestMove, Depth _depth, Eval _eval, Eval 
     }
 }
 
-__attribute__((no_sanitize("thread")))
-TTEntry* TranspositionTable::probe(Hash hash, uint8_t fmr, bool* found) {
-    TTCluster* cluster = &table[index(hash, fmr)];
+TTEntry* TranspositionTable::probe(Hash hash, bool* found) {
+    TTCluster* cluster = &table[index(hash)];
     uint16_t hash16 = (uint16_t)hash;
 
     TTEntry* replace = &cluster->entries[0];

--- a/src/tt.h
+++ b/src/tt.h
@@ -17,7 +17,6 @@
 #include "move.h"
 #include "evaluation.h"
 #include "uci.h"
-#include "zobrist.h"
 
 inline void* alignedAlloc(size_t alignment, size_t requiredBytes) {
     void* ptr;
@@ -73,7 +72,6 @@ struct TTEntry {
     constexpr Eval getValue() { return value; };
     constexpr bool getTtPv() { return flags & 0x4; };
 
-    __attribute__((no_sanitize("thread")))
     void update(Hash _hash, Move _bestMove, Depth _depth, Eval _eval, Eval _value, uint8_t rule50, bool wasPv, int _flags);
     bool isInitialised() { return hash != 0; };
 };
@@ -122,21 +120,17 @@ public:
         clear();
     }
 
-    size_t index(Hash hash, uint8_t fmr) {
-        // Modify hash using 50mr count
-        hash ^= Zobrist::FMR[fmr / Zobrist::FMR_GRANULARITY];
-
+    size_t index(Hash hash) {
         // Find entry
         __extension__ using uint128 = unsigned __int128;
         return ((uint128)hash * (uint128)clusterCount) >> 64;
     }
 
-    void prefetch(Hash hash, uint8_t fmr) {
-        __builtin_prefetch(&table[index(hash, fmr)]);
+    void prefetch(Hash hash) {
+        __builtin_prefetch(&table[index(hash)]);
     }
 
-    __attribute__((no_sanitize("thread")))
-    TTEntry* probe(Hash hash, uint8_t fmr, bool* found);
+    TTEntry* probe(Hash hash, bool* found);
 
     int hashfull() {
         int count = 0;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -210,7 +210,7 @@ void position(std::string line, Board& board, std::vector<Hash>& boardHistory) {
         assert(board.isLegal(m));
 
         Board boardCopy = board;
-        boardCopy.doMove(m, board.hashAfter(m), &UCI::nnue);
+        boardCopy.doMove(m, board.hashAfter(m).first, &UCI::nnue);
         boardHistory.push_back(boardCopy.hashes.hash);
 
         if (moveCount++ > 200) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.42";
+constexpr auto VERSION = "7.0.43";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 0.13 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 46242 W: 11316 L: 11299 D: 23627
Penta | [78, 5338, 12270, 5359, 76]
```
https://furybench.com/test/4329/

Bench: 2017711