### PR TITLE
Scale down old quiet history entries before each new search

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -16,7 +16,6 @@ constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 
 class History {
 
-    int16_t quietHistory[2][64][2][64][2];
     Move counterMoves[64][64];
     int16_t captureHistory[2][Piece::TOTAL][64][Piece::TOTAL];
 
@@ -28,6 +27,8 @@ class History {
     int16_t pawnHistory[PAWN_HISTORY_SIZE][2][Piece::TOTAL][64];
 
 public:
+
+    int16_t quietHistory[2][64][2][64][2];
 
     int16_t continuationHistory[2][Piece::TOTAL][64][Piece::TOTAL * 64 * 2];
     int16_t continuationCorrectionHistory[2][Piece::TOTAL][64][2][2];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1327,6 +1327,13 @@ void Worker::tsearch() {
 }
 
 void Worker::iterativeDeepening() {
+    for (auto& a : history.quietHistory)
+        for (auto& b : a)
+            for (auto& c : b)
+                for (auto& d : c)
+                    for (auto& e : d)
+                        e = 3 * e / 4;
+
     int multiPvCount = 0;
     {
         MoveList moves;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.45";
+constexpr auto VERSION = "7.0.46";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.12 +- 0.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 133056 W: 32730 L: 32300 D: 68026
Penta | [194, 14775, 36167, 15191, 201]
https://furybench.com/test/4366/
```

Bench: 2011252