### PR TITLE
Tune search with 4 threads

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -8,14 +8,14 @@
 #include "nnue.h"
 #include "spsa.h"
 
-TUNE_INT(materialScalePawnValue, 96, 1, 200);
-TUNE_INT(materialScaleKnightValue, 298, 1, 600);
-TUNE_INT(materialScaleBishopValue, 301, 1, 600);
-TUNE_INT(materialScaleRookValue, 507, 1, 1000);
-TUNE_INT(materialScaleQueenValue, 909, 1, 2000);
+TUNE_INT(materialScalePawnValue, 86, 1, 200);
+TUNE_INT(materialScaleKnightValue, 290, 1, 600);
+TUNE_INT(materialScaleBishopValue, 313, 1, 600);
+TUNE_INT(materialScaleRookValue, 506, 1, 1000);
+TUNE_INT(materialScaleQueenValue, 1033, 1, 2000);
 
-TUNE_INT(materialScaleBase, 920, 1, 2000);
-TUNE_INT(materialScaleDivisor, 48, 1, 100);
+TUNE_INT(materialScaleBase, 870, 1, 2000);
+TUNE_INT(materialScaleDivisor, 38, 1, 100);
 
 int PIECE_VALUES[Piece::TOTAL + 1] = {
     96, 298, 301, 507, 909, 0, 0

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -8,45 +8,45 @@
 #include "spsa.h"
 
 // Quiet history
-TUNE_INT(historyBonusQuietBase, 140, 0, 250);
-TUNE_INT(historyBonusQuietFactor, 264, 1, 500);
-TUNE_INT(historyBonusQuietMax, 2150, 1, 4000);
-TUNE_INT(historyMalusQuietBase, 106, 0, 250);
-TUNE_INT(historyMalusQuietFactor, 239, 1, 500);
-TUNE_INT(historyMalusQuietMax, 1520, 1, 3000);
+TUNE_INT(historyBonusQuietBase, 139, 0, 250);
+TUNE_INT(historyBonusQuietFactor, 269, 1, 500);
+TUNE_INT(historyBonusQuietMax, 2083, 1, 4000);
+TUNE_INT(historyMalusQuietBase, 108, 0, 250);
+TUNE_INT(historyMalusQuietFactor, 209, 1, 500);
+TUNE_INT(historyMalusQuietMax, 1627, 1, 3000);
 
 // Continuation history
-TUNE_INT(historyBonusContinuationBase, -77, -200, 0);
-TUNE_INT(historyBonusContinuationFactor, 132, 1, 250);
-TUNE_INT(historyBonusContinuationMax, 2035, 1, 4000);
-TUNE_INT(historyMalusContinuationBase, 102, 0, 200);
-TUNE_INT(historyMalusContinuationFactor, 273, 1, 500);
-TUNE_INT(historyMalusContinuationMax, 835, 1, 1500);
+TUNE_INT(historyBonusContinuationBase, -87, -200, 0);
+TUNE_INT(historyBonusContinuationFactor, 134, 1, 250);
+TUNE_INT(historyBonusContinuationMax, 1868, 1, 4000);
+TUNE_INT(historyMalusContinuationBase, 109, 0, 200);
+TUNE_INT(historyMalusContinuationFactor, 259, 1, 500);
+TUNE_INT(historyMalusContinuationMax, 860, 1, 1500);
 
 // Pawn history
-TUNE_INT(historyBonusPawnBase, 39, -100, 100);
-TUNE_INT(historyBonusPawnFactor, 170, 1, 250);
-TUNE_INT(historyBonusPawnMax, 2070, 1, 4000);
-TUNE_INT(historyMalusPawnBase, 29, -100, 100);
-TUNE_INT(historyMalusPawnFactor, 288, 1, 500);
-TUNE_INT(historyMalusPawnMax, 2148, 1, 4000);
+TUNE_INT(historyBonusPawnBase, 42, -100, 100);
+TUNE_INT(historyBonusPawnFactor, 152, 1, 250);
+TUNE_INT(historyBonusPawnMax, 1945, 1, 4000);
+TUNE_INT(historyMalusPawnBase, 27, -100, 100);
+TUNE_INT(historyMalusPawnFactor, 296, 1, 500);
+TUNE_INT(historyMalusPawnMax, 2254, 1, 4000);
 
 // Capture history
-TUNE_INT(historyBonusCaptureBase, 14, -100, 100);
-TUNE_INT(historyBonusCaptureFactor, 115, 1, 250);
-TUNE_INT(historyBonusCaptureMax, 1325, 1, 2500);
-TUNE_INT(historyMalusCaptureBase, 97, 0, 200);
-TUNE_INT(historyMalusCaptureFactor, 236, 1, 500);
-TUNE_INT(historyMalusCaptureMax, 1486, 1, 3000);
+TUNE_INT(historyBonusCaptureBase, 21, -100, 100);
+TUNE_INT(historyBonusCaptureFactor, 112, 1, 250);
+TUNE_INT(historyBonusCaptureMax, 1422, 1, 2500);
+TUNE_INT(historyMalusCaptureBase, 86, 0, 200);
+TUNE_INT(historyMalusCaptureFactor, 262, 1, 500);
+TUNE_INT(historyMalusCaptureMax, 1598, 1, 3000);
 
 // Correction history
-TUNE_INT(pawnCorrectionFactor, 6429, 1000, 7500);
-TUNE_INT(nonPawnCorrectionFactor, 5827, 1000, 7500);
-TUNE_INT(minorCorrectionFactor, 4178, 1000, 7500);
-TUNE_INT(majorCorrectionFactor, 2295, 1000, 7500);
-TUNE_INT(continuationCorrectionFactor, 5762, 1000, 7500);
+TUNE_INT(pawnCorrectionFactor, 6252, 1000, 7500);
+TUNE_INT(nonPawnCorrectionFactor, 5916, 1000, 7500);
+TUNE_INT(minorCorrectionFactor, 4109, 1000, 7500);
+TUNE_INT(majorCorrectionFactor, 2627, 1000, 7500);
+TUNE_INT(continuationCorrectionFactor, 6019, 1000, 7500);
 
-TUNE_INT(fiftyMoveRuleScaleFactor, 300, 100, 300);
+TUNE_INT(fiftyMoveRuleScaleFactor, 293, 100, 300);
 
 void History::initHistory() {
     memset(quietHistory, 0, sizeof(quietHistory));

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -15,11 +15,11 @@
 
 TUNE_INT_DISABLED(mpPromotionScoreFactor, 101, 10, 10000);
 TUNE_INT_DISABLED(mpMvvLvaScoreFactor, 147, 10, 10000);
-TUNE_INT(mpSeeDivisor, 83, 10, 150);
+TUNE_INT(mpSeeDivisor, 80, 10, 150);
 
-TUNE_INT(mpThreatQueenValue, 20000, 10000, 30000);
-TUNE_INT(mpThreatRookValue, 12500, 7500, 17500);
-TUNE_INT(mpThreatKnightValue, 7500, 5000, 10000);
+TUNE_INT(mpThreatQueenValue, 19431, 10000, 30000);
+TUNE_INT(mpThreatRookValue, 12315, 7500, 17500);
+TUNE_INT(mpThreatKnightValue, 7973, 5000, 10000);
 
 void generatePawn_quiet(Board* board, MoveList& moves, Bitboard targetMask) {
     Bitboard pawns = board->byPiece[Piece::PAWN] & board->byColor[board->stm];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -41,130 +41,130 @@ TUNE_INT_DISABLED(aspirationWindowMinDepth, 4, 2, 6);
 TUNE_INT_DISABLED(aspirationWindowDelta, 14, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowDeltaBase, 10, 1, 30);
 TUNE_INT_DISABLED(aspirationWindowMaxFailHighs, 3, 1, 10);
-TUNE_FLOAT(aspirationWindowDeltaFactor, 1.6824316885254968f, 1.0f, 3.0f);
-TUNE_INT(aspirationWindowDeltaDivisor, 13052, 7500, 17500);
+TUNE_FLOAT(aspirationWindowDeltaFactor, 1.741778462976496f, 1.0f, 3.0f);
+TUNE_INT(aspirationWindowDeltaDivisor, 12928, 7500, 17500);
 
 // Reduction / Margin tables
-TUNE_FLOAT(lmrReductionNoisyBase, -0.16746504757915998f, -1.0f, 1.0f);
-TUNE_FLOAT(lmrReductionNoisyFactor, 3.015294386647946f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.18494142853230522f, -1.0f, 1.0f);
-TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.1771025906820594f, 2.0f, 4.0f);
-TUNE_FLOAT(lmrReductionQuietBase, 1.1156812184145881f, 0.0f, 2.0f);
-TUNE_FLOAT(lmrReductionQuietFactor, 2.9348373864040274f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionNoisyBase, -0.23158315137507635f, -1.0f, 1.0f);
+TUNE_FLOAT(lmrReductionNoisyFactor, 2.9819903465034674f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionImportantNoisyBase, -0.1336497899121309f, -1.0f, 1.0f);
+TUNE_FLOAT(lmrReductionImportantNoisyFactor, 3.174231573547516f, 2.0f, 4.0f);
+TUNE_FLOAT(lmrReductionQuietBase, 1.1203658354016672f, 0.0f, 2.0f);
+TUNE_FLOAT(lmrReductionQuietFactor, 2.947877296606716f, 2.0f, 4.0f);
 
-TUNE_FLOAT(lmpMarginWorseningBase, 1.976556330827873f, 0.0f, 3.5f);
-TUNE_FLOAT(lmpMarginWorseningFactor, 0.4409114850475385f, 0.1f, 1.5f);
-TUNE_FLOAT(lmpMarginWorseningPower, 1.539323819754223f, 0.0f, 4.0f);
-TUNE_FLOAT(lmpMarginImprovingBase, 2.837411229046308f, 2.0f, 5.0f);
-TUNE_FLOAT(lmpMarginImprovingFactor, 0.8604609467433942f, 0.5f, 2.0f);
-TUNE_FLOAT(lmpMarginImprovingPower, 1.9566999909630995f, 1.0f, 3.0f);
+TUNE_FLOAT(lmpMarginWorseningBase, 1.9586367509339555f, 0.0f, 3.5f);
+TUNE_FLOAT(lmpMarginWorseningFactor, 0.4695734030291108f, 0.1f, 1.5f);
+TUNE_FLOAT(lmpMarginWorseningPower, 1.6220638123840003f, 0.0f, 4.0f);
+TUNE_FLOAT(lmpMarginImprovingBase, 2.863191493839467f, 2.0f, 5.0f);
+TUNE_FLOAT(lmpMarginImprovingFactor, 0.8748193194885028f, 0.5f, 2.0f);
+TUNE_FLOAT(lmpMarginImprovingPower, 1.9492352282965961f, 1.0f, 3.0f);
 
 // Search values
-TUNE_INT(qsFutilityOffset, 83, 1, 125);
-TUNE_INT(qsFutilityOffsetInCheck, 0, 0, 125);
-TUNE_INT(qsSeeMargin, -68, -200, 50);
+TUNE_INT(qsFutilityOffset, 80, 1, 125);
+TUNE_INT(qsFutilityOffsetInCheck, 5, 0, 125);
+TUNE_INT(qsSeeMargin, -62, -200, 50);
 
 // Pre-search pruning
-TUNE_INT(ttCutOffset, 43, 0, 100);
-TUNE_INT(ttCutFailHighMargin, 123, 0, 240);
+TUNE_INT(ttCutOffset, 44, 0, 100);
+TUNE_INT(ttCutFailHighMargin, 122, 0, 240);
 
-TUNE_INT(iirMinDepth, 257, 100, 500);
-TUNE_INT(iirCheckDepth, 509, 0, 1000);
-TUNE_INT(iirLowTtDepthOffset, 437, 0, 850);
-TUNE_INT(iirReduction, 90, 0, 200);
+TUNE_INT(iirMinDepth, 288, 100, 500);
+TUNE_INT(iirCheckDepth, 423, 0, 1000);
+TUNE_INT(iirLowTtDepthOffset, 467, 0, 850);
+TUNE_INT(iirReduction, 88, 0, 200);
 
-TUNE_INT(staticHistoryFactor, -250, -500, -1);
-TUNE_INT(staticHistoryMin, -430, -860, -1);
-TUNE_INT(staticHistoryMax, 715, 1, 1400);
-TUNE_INT(staticHistoryTempo, 170, 1, 350);
+TUNE_INT(staticHistoryFactor, -242, -500, -1);
+TUNE_INT(staticHistoryMin, -428, -860, -1);
+TUNE_INT(staticHistoryMax, 6393, 1, 1400);
+TUNE_INT(staticHistoryTempo, 163, 1, 350);
 
-TUNE_INT(rfpDepthLimit, 1450, 200, 2000);
-TUNE_INT(rfpBase, 17, -100, 100);
-TUNE_INT(rfpFactorLinear, 31, 1, 60);
-TUNE_INT(rfpFactorQuadratic, 700, 1, 1200);
-TUNE_INT(rfpImprovingOffset, 101, 1, 200);
-TUNE_INT(rfpBaseCheck, -5, -100, 100);
-TUNE_INT(rfpFactorLinearCheck, 39, 1, 80);
-TUNE_INT(rfpFactorQuadraticCheck, 507, 1, 1200);
-TUNE_INT(rfpImprovingOffsetCheck, 98, 1, 200);
+TUNE_INT(rfpDepthLimit, 1520, 200, 2000);
+TUNE_INT(rfpBase, 18, -100, 100);
+TUNE_INT(rfpFactorLinear, 29, 1, 60);
+TUNE_INT(rfpFactorQuadratic, 718, 1, 1200);
+TUNE_INT(rfpImprovingOffset, 110, 1, 200);
+TUNE_INT(rfpBaseCheck, -1, -100, 100);
+TUNE_INT(rfpFactorLinearCheck, 46, 1, 80);
+TUNE_INT(rfpFactorQuadraticCheck, 526, 1, 1200);
+TUNE_INT(rfpImprovingOffsetCheck, 90, 1, 200);
 
-TUNE_INT(razoringDepth, 528, 100, 1000);
-TUNE_INT(razoringFactor, 267, 1, 500);
+TUNE_INT(razoringDepth, 568, 100, 1000);
+TUNE_INT(razoringFactor, 255, 1, 500);
 
-TUNE_INT(nmpMinDepth, 355, 0, 700);
-TUNE_INT(nmpRedBase, 365, 100, 700);
-TUNE_INT(nmpDepthDiv, 246, 100, 500);
-TUNE_INT(nmpMin, 380, 100, 700);
+TUNE_INT(nmpMinDepth, 378, 0, 700);
+TUNE_INT(nmpRedBase, 351, 100, 700);
+TUNE_INT(nmpDepthDiv, 243, 100, 500);
+TUNE_INT(nmpMin, 400, 100, 700);
 TUNE_INT(nmpDivisor, 211, 10, 500);
 TUNE_INT_DISABLED(nmpEvalDepth, 7, 1, 100);
-TUNE_INT(nmpEvalBase, 164, 50, 350);
+TUNE_INT(nmpEvalBase, 170, 50, 350);
 
-TUNE_INT(probcutReduction, 409, 0, 800);
-TUNE_INT(probCutBetaOffset, 206, 1, 400);
-TUNE_INT(probCutDepth, 560, 100, 1000);
+TUNE_INT(probcutReduction, 403, 0, 800);
+TUNE_INT(probCutBetaOffset, 214, 1, 400);
+TUNE_INT(probCutDepth, 614, 100, 1000);
 
-TUNE_INT(iir2Reduction, 101, 0, 200);
-TUNE_INT(iir2MinDepth, 266, 100, 500);
+TUNE_INT(iir2Reduction, 100, 0, 200);
+TUNE_INT(iir2MinDepth, 251, 100, 500);
 
 // In-search pruning
-TUNE_INT(earlyLmrImproving, 123, 1, 260);
+TUNE_INT(earlyLmrImproving, 114, 1, 260);
 
-TUNE_INT(earlyLmrHistoryFactorQuiet, 15842, 10000, 20000);
-TUNE_INT(earlyLmrHistoryFactorCapture, 14293, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorQuiet, 15725, 10000, 20000);
+TUNE_INT(earlyLmrHistoryFactorCapture, 14179, 10000, 20000);
 
-TUNE_INT(fpDepth, 1097, 100, 2000);
-TUNE_INT(fpBase, 295, 1, 600);
-TUNE_INT(fpFactor, 70, 1, 150);
-TUNE_INT(fpPvNode, 36, 1, 80);
-TUNE_INT(fpNoBestMove, 117, 1, 250);
-TUNE_INT(fpConthistDivisor, 500, 1, 1000);
+TUNE_INT(fpDepth, 1222, 100, 2000);
+TUNE_INT(fpBase, 278, 1, 600);
+TUNE_INT(fpFactor, 74, 1, 150);
+TUNE_INT(fpPvNode, 34, 1, 80);
+TUNE_INT(fpNoBestMove, 113, 1, 250);
+TUNE_INT(fpConthistDivisor, 488, 1, 1000);
 
-TUNE_INT(bnfpDepth, 1097, 100, 2000);
-TUNE_INT(bnfpBase, 295, 1, 600);
-TUNE_INT(bnfpFactor, 70, 1, 150);
-TUNE_INT(bnfpPvNode, 36, 1, 80);
-TUNE_INT(bnfpNoBestMove, 117, 1, 250);
+TUNE_INT(bnfpDepth, 1077, 100, 2000);
+TUNE_INT(bnfpBase, 292, 1, 600);
+TUNE_INT(bnfpFactor, 71, 1, 150);
+TUNE_INT(bnfpPvNode, 35, 1, 80);
+TUNE_INT(bnfpNoBestMove, 116, 1, 250);
 
-TUNE_INT(fpCaptDepth, 846, 100, 1500);
-TUNE_INT(fpCaptBase, 432, 150, 800);
-TUNE_INT(fpCaptFactor, 397, 100, 800);
+TUNE_INT(fpCaptDepth, 902, 100, 1500);
+TUNE_INT(fpCaptBase, 383, 150, 800);
+TUNE_INT(fpCaptFactor, 345, 100, 800);
 
-TUNE_INT(historyPruningDepth, 457, 100, 1000);
-TUNE_INT(historyPruningFactorCapture, -2170, -4000, -1);
-TUNE_INT(historyPruningFactorQuiet, -6724, -12000, -1);
+TUNE_INT(historyPruningDepth, 468, 100, 1000);
+TUNE_INT(historyPruningFactorCapture, -2074, -4000, -1);
+TUNE_INT(historyPruningFactorQuiet, -6796, -12000, -1);
 
 TUNE_INT(seeMarginCapture, -22, -44, -1);
-TUNE_INT(seeMarginQuiet, -73, -146, -1);
+TUNE_INT(seeMarginQuiet, -74, -146, -1);
 
-TUNE_INT(extensionMinDepth, 620, 0, 1200);
-TUNE_INT(extensionTtDepthOffset, 470, 0, 800);
-TUNE_INT(doubleExtensionDepthIncreaseFactor, 79, 0, 200);
+TUNE_INT(extensionMinDepth, 624, 0, 1200);
+TUNE_INT(extensionTtDepthOffset, 499, 0, 800);
+TUNE_INT(doubleExtensionDepthIncreaseFactor, 100, 0, 200);
 TUNE_INT_DISABLED(doubleExtensionMargin, 6, 1, 30);
 TUNE_INT(doubleExtensionDepthIncrease, 1002, 200, 2000);
 TUNE_INT_DISABLED(tripleExtensionMargin, 41, 25, 100);
 
 TUNE_INT_DISABLED(lmrMcBase, 2, 1, 10);
 TUNE_INT_DISABLED(lmrMcPv, 2, 1, 10);
-TUNE_INT(lmrMinDepth, 307, 100, 600);
+TUNE_INT(lmrMinDepth, 322, 100, 600);
 
-TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 145, 0, 300);
-TUNE_INT(lmrReductionOffsetImportantCapture, 7, 0, 100);
+TUNE_INT(lmrReductionOffsetQuietOrNormalCapture, 134, 0, 300);
+TUNE_INT(lmrReductionOffsetImportantCapture, 9, 0, 100);
 TUNE_INT(lmrCheckQuietOrNormalCapture, 108, 0, 230);
-TUNE_INT(lmrCheckImportantCapture, 58, 0, 120);
-TUNE_INT(lmrTtPvQuietOrNormalCapture, 191, 0, 400);
-TUNE_INT(lmrTtPvImportantCapture, 197, 0, 400);
-TUNE_INT(lmrCutnode, 267, 0, 500);
-TUNE_INT(lmrTtpvFaillowQuietOrNormalCapture, 46, 0, 100);
-TUNE_INT(lmrTtpvFaillowImportantCapture, 87, 0, 200);
-TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 140128, 100000, 200000);
-TUNE_INT(lmrCorrectionDivisorImportantCapture, 146432, 100000, 200000);
-TUNE_INT(lmrQuietHistoryDivisor, 28908, 10000, 60000);
-TUNE_INT(lmrHistoryFactorCapture, 3122217, 2500000, 4000000);
-TUNE_INT(lmrHistoryFactorImportantCapture, 3006170, 2500000, 4000000);
-TUNE_INT(lmrImportantBadCaptureOffset, 110, 0, 230);
-TUNE_INT(lmrImportantCaptureFactor, 31, 0, 60);
-TUNE_INT(lmrQuietPvNodeOffset, 19, 0, 50);
-TUNE_INT(lmrQuietImproving, 58, 0, 100);
+TUNE_INT(lmrCheckImportantCapture, 63, 0, 120);
+TUNE_INT(lmrTtPvQuietOrNormalCapture, 169, 0, 400);
+TUNE_INT(lmrTtPvImportantCapture, 188, 0, 400);
+TUNE_INT(lmrCutnode, 262, 0, 500);
+TUNE_INT(lmrTtpvFaillowQuietOrNormalCapture, 48, 0, 100);
+TUNE_INT(lmrTtpvFaillowImportantCapture, 82, 0, 200);
+TUNE_INT(lmrCorrectionDivisorQuietOrNormalCapture, 142482, 100000, 200000);
+TUNE_INT(lmrCorrectionDivisorImportantCapture, 142438, 100000, 200000);
+TUNE_INT(lmrQuietHistoryDivisor, 28812, 10000, 60000);
+TUNE_INT(lmrHistoryFactorCapture, 3156141, 2500000, 4000000);
+TUNE_INT(lmrHistoryFactorImportantCapture, 2948964, 2500000, 4000000);
+TUNE_INT(lmrImportantBadCaptureOffset, 119, 0, 230);
+TUNE_INT(lmrImportantCaptureFactor, 29, 0, 60);
+TUNE_INT(lmrQuietPvNodeOffset, 22, 0, 50);
+TUNE_INT(lmrQuietImproving, 54, 0, 100);
 
 inline int lmrReductionOffset(bool importantCapture) { return importantCapture ? lmrReductionOffsetImportantCapture : lmrReductionOffsetQuietOrNormalCapture; }
 inline int lmrCheck(bool importantCapture) { return importantCapture ? lmrCheckImportantCapture : lmrCheckQuietOrNormalCapture; }
@@ -173,29 +173,29 @@ inline int lmrTtpvFaillow(bool importantCapture) { return importantCapture ? lmr
 inline int lmrCaptureHistoryDivisor(bool importantCapture) { return importantCapture ? lmrHistoryFactorImportantCapture : lmrHistoryFactorCapture; }
 inline int lmrCorrectionDivisor(bool importantCapture) { return importantCapture ? lmrCorrectionDivisorImportantCapture : lmrCorrectionDivisorQuietOrNormalCapture; }
 
-TUNE_INT(postlmrOppWorseningThreshold, 240, 150, 450);
-TUNE_INT(postlmrOppWorseningReduction, 145, 0, 200);
+TUNE_INT(postlmrOppWorseningThreshold, 220, 150, 450);
+TUNE_INT(postlmrOppWorseningReduction, 152, 0, 200);
 
-TUNE_INT(lmrPotentialExtension, 100, 0, 200);
-TUNE_INT(lmrPvNodeExtension, 109, 0, 200);
+TUNE_INT(lmrPotentialExtension, 105, 0, 200);
+TUNE_INT(lmrPvNodeExtension, 124, 0, 200);
 TUNE_INT_DISABLED(lmrDeeperBase, 40, 1, 100);
 TUNE_INT_DISABLED(lmrDeeperFactor, 2, 0, 10);
-TUNE_INT(lmrDeeperWeight, 112, 0, 200);
-TUNE_INT(lmrShallowerWeight, 111, 0, 200);
-TUNE_INT(lmrResearchSkipDepthOffset, 432, 0, 800);
+TUNE_INT(lmrDeeperWeight, 116, 0, 200);
+TUNE_INT(lmrShallowerWeight, 114, 0, 200);
+TUNE_INT(lmrResearchSkipDepthOffset, 435, 0, 800);
 
 TUNE_INT(lmrPassBonusBase, -293, -500, 0);
-TUNE_INT(lmrPassBonusFactor, 154, 1, 300);
-TUNE_INT(lmrPassBonusMax, 1012, 0, 2000);
+TUNE_INT(lmrPassBonusFactor, 148, 1, 300);
+TUNE_INT(lmrPassBonusMax, 1054, 0, 2000);
 
-TUNE_INT(historyDepthBetaOffset, 218, 1, 400);
+TUNE_INT(historyDepthBetaOffset, 209, 1, 400);
 
-TUNE_INT(lowDepthPvDepthReductionMin, 423, 0, 800);
-TUNE_INT(lowDepthPvDepthReductionMax, 1095, 0, 2000);
-TUNE_INT(lowDepthPvDepthReductionWeight, 110, 0, 200);
+TUNE_INT(lowDepthPvDepthReductionMin, 404, 0, 800);
+TUNE_INT(lowDepthPvDepthReductionMax, 1021, 0, 2000);
+TUNE_INT(lowDepthPvDepthReductionWeight, 105, 0, 200);
 
-TUNE_INT(correctionHistoryFactor, 120, 0, 300);
-TUNE_INT(correctionHistoryFactorMulticut, 164, 0, 300);
+TUNE_INT(correctionHistoryFactor, 118, 0, 300);
+TUNE_INT(correctionHistoryFactorMulticut, 177, 0, 300);
 
 int REDUCTIONS[3][MAX_PLY][MAX_MOVES];
 int LMP_MARGIN[MAX_PLY][2];

--- a/src/spsa.h
+++ b/src/spsa.h
@@ -92,7 +92,7 @@ public:
 
 };
 
-#define TUNE_ENABLED true
+#define TUNE_ENABLED false
 
 // Some fancy macro stuff to call the tune() methods inline from anywhere
 #define STRINGIFY(x) #x

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -2,8 +2,8 @@
 #include "move.h"
 #include "spsa.h"
 
-TUNE_INT(ttReplaceTtpvBonus, 225, 0, 400);
-TUNE_INT(ttReplaceOffset, 443, 0, 800);
+TUNE_INT(ttReplaceTtpvBonus, 231, 0, 400);
+TUNE_INT(ttReplaceOffset, 432, 0, 800);
 
 void TTEntry::update(Hash _hash, Move _bestMove, Depth _depth, Eval _eval, Eval _value, uint8_t _rule50, bool wasPv, int _flags) {
     // Update bestMove if it exists

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.48";
+constexpr auto VERSION = "7.0.49";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 2.02 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.38 (-2.25, 2.89) [0.00, 2.50]
Games | N: 40654 W: 10059 L: 9823 D: 20772
Penta | [61, 4630, 10696, 4892, 48]
https://furybench.com/test/4608/
```
LTC
```
Elo   | 0.95 +- 2.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.28 (-2.25, 2.89) [0.00, 2.50]
Games | N: 18348 W: 4507 L: 4457 D: 9384
Penta | [12, 2037, 5023, 2093, 9]
https://furybench.com/test/4609/
```
4th LTC
```
Elo   | 5.40 +- 2.93 (95%)
SPRT  | 40.0+0.40s Threads=4 Hash=256MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11450 W: 2871 L: 2693 D: 5886
Penta | [1, 1126, 3292, 1306, 0]
https://furybench.com/test/4607/
```

Bench: 2595979