### PR TITLE
Add WebAssembly/Emscripten support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tools/process_net
 datagen_scrape/
 .vscode
 src/fathom/src/*.o
+engine.js
+engine.wasm

--- a/README.md
+++ b/README.md
@@ -67,3 +67,22 @@ Profiled builds do not currently work with compilers installed via MinGW/msys2.
 Building an Android binary requires a linux device with NDK installed.
 
 The Makefile will automatically use the NDK compiler when invoked with `arch=android`.
+
+## Building for WebAssembly
+
+Requires [Emscripten](https://emscripten.org/docs/getting_started/downloads.html).
+
+```bash
+source /path/to/emsdk/emsdk_env.sh
+make arch=wasm-simd   # SIMD build (recommended)
+make arch=wasm        # scalar fallback
+```
+
+Outputs `engine.js` and `engine.wasm`. Serve with a local web server and open `wasm_example.html`:
+
+```bash
+python3 -m http.server 8000
+# Open http://localhost:8000/wasm_example.html
+```
+
+Note: Runs single-threaded. Deep searches block the browser UI.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -2,8 +2,10 @@
 #include <inttypes.h>
 #include <deque>
 #include <string.h>
+#ifndef ARCH_WASM
 #include <mutex>
 #include <condition_variable>
+#endif
 
 #include "thread.h"
 #include "search.h"
@@ -28,18 +30,34 @@ void Worker::startSearching() {
         searchData.nodesSearched = perft(rootBoard, searchParameters.depth);
     else if (searchParameters.genfens)
         tgenfens();
+#ifndef ARCH_WASM
     else if (UCI::Options.datagen.value)
         tdatagen();
+#endif
     else
         tsearch();
+
+#ifdef ARCH_WASM
+    // In Wasm, mark search as finished immediately
+    searching = false;
+#endif
 }
 
 void Worker::waitForSearchFinished() {
+#ifdef ARCH_WASM
+    // In Wasm, search is synchronous, nothing to wait for
+    (void)0;
+#else
     std::unique_lock<std::mutex> lock(mutex);
     cv.wait(lock, [&] { return !searching; });
+#endif
 }
 
 void Worker::idle() {
+#ifdef ARCH_WASM
+    // In Wasm, we don't use the idle loop - search is called directly
+    threadPool->startedThreads++;
+#else
     threadPool->startedThreads++;
 
     while (!exiting) {
@@ -54,9 +72,14 @@ void Worker::idle() {
 
         cv.notify_all();
     }
+#endif
 }
 
 void Worker::exit() {
+#ifdef ARCH_WASM
+    // In Wasm, nothing to do - no threads to join
+    exiting = true;
+#else
     {
         std::lock_guard<std::mutex> lock(mutex);
         searching = true;
@@ -65,6 +88,7 @@ void Worker::exit() {
     cv.notify_all();
     if (threadPool->threads[threadId]->joinable())
         threadPool->threads[threadId]->join();
+#endif
 }
 
 void Worker::ucinewgame() {

--- a/src/uci.h
+++ b/src/uci.h
@@ -80,7 +80,11 @@ namespace UCI {
             1,
             1,
             1,
+#ifdef ARCH_WASM
+            1  // Wasm is single-threaded
+#else
             4096
+#endif
         };
 
         UCIOption<UCI_SPIN> multiPV = {

--- a/src/wasm_glue.cpp
+++ b/src/wasm_glue.cpp
@@ -1,0 +1,108 @@
+#ifdef ARCH_WASM
+
+#include <string>
+#include <deque>
+#include <cstring>
+#include <sstream>
+
+// Forward declaration of initNetworkData from nnue.cpp
+extern void initNetworkData();
+
+// Forward declaration of processCommand from uci.cpp
+extern void processCommand(const std::string& line);
+
+// Command queue for receiving commands from JavaScript
+static std::deque<std::string> commandQueue;
+
+// Output buffer for sending output to JavaScript
+static std::stringstream outputBuffer;
+
+// Flag to check if engine is initialized
+static bool wasmInitialized = false;
+
+extern "C" {
+
+// Initialize the engine (called from JavaScript)
+void wasm_init() {
+    initNetworkData();
+    wasmInitialized = true;
+}
+
+// Process all pending commands (called from JavaScript after sending commands)
+void wasm_process_commands() {
+    std::string cmd;
+    while (!commandQueue.empty()) {
+        cmd = commandQueue.front();
+        commandQueue.pop_front();
+        processCommand(cmd);
+    }
+}
+
+// Send a command to the engine (called from JavaScript)
+void wasm_send_command(const char* cmd) {
+    if (cmd) {
+        commandQueue.push_back(std::string(cmd));
+    }
+}
+
+// Get output from the engine (called from JavaScript)
+// Returns a pointer to a static buffer that is valid until the next call
+const char* wasm_get_output() {
+    static std::string outputStr;
+    outputStr = outputBuffer.str();
+    outputBuffer.str("");
+    outputBuffer.clear();
+    return outputStr.c_str();
+}
+
+// Check if there are pending commands
+bool wasm_has_command() {
+    return !commandQueue.empty();
+}
+
+// Get the next command (for internal use)
+bool wasm_get_next_command(std::string& out) {
+    if (commandQueue.empty()) {
+        return false;
+    }
+    out = commandQueue.front();
+    commandQueue.pop_front();
+    return true;
+}
+
+// Redirect output for Wasm (called from engine code)
+void wasm_output(const std::string& str) {
+    outputBuffer << str;
+}
+
+} // extern "C"
+
+// Override std::cout for Wasm
+#include <iostream>
+
+namespace WasmIO {
+    class WasmStreamBuf : public std::streambuf {
+    protected:
+        virtual int overflow(int c) override {
+            if (c != EOF) {
+                char ch = static_cast<char>(c);
+                outputBuffer.put(ch);
+            }
+            return c;
+        }
+
+        virtual std::streamsize xsputn(const char* s, std::streamsize n) override {
+            outputBuffer.write(s, n);
+            return n;
+        }
+    };
+
+    static WasmStreamBuf wasmStreamBuf;
+
+    void initWasmIO() {
+        std::cout.rdbuf(&wasmStreamBuf);
+        std::cerr.rdbuf(&wasmStreamBuf);
+    }
+}
+
+#endif // ARCH_WASM

--- a/wasm_example.html
+++ b/wasm_example.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PlentyChess Wasm Example</title>
+    <style>
+        body {
+            font-family: monospace;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        #output {
+            background: #1a1a1a;
+            color: #00ff00;
+            padding: 10px;
+            height: 400px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+            font-size: 12px;
+        }
+        #input {
+            width: 100%;
+            font-family: monospace;
+            font-size: 14px;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+        button {
+            padding: 10px 20px;
+            margin: 5px;
+            cursor: pointer;
+        }
+        .controls {
+            margin: 10px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>PlentyChess WebAssembly Demo</h1>
+    <p>A chess engine running in your browser via WebAssembly.</p>
+
+    <div class="controls">
+        <button onclick="sendCommand('uci')">UCI</button>
+        <button onclick="sendCommand('isready')">Is Ready</button>
+        <button onclick="sendCommand('ucinewgame')">New Game</button>
+        <button onclick="sendCommand('position startpos')">Start Position</button>
+        <button onclick="sendCommand('go depth 10')">Go (depth 10)</button>
+        <button onclick="sendCommand('stop')">Stop</button>
+        <button onclick="sendCommand('bench')">Benchmark</button>
+    </div>
+
+    <div id="output"></div>
+    <input type="text" id="input" placeholder="Enter UCI command..." onkeypress="handleKeyPress(event)">
+
+    <h3>Usage</h3>
+    <p>Build with: <code>make arch=wasm-simd</code> or <code>make arch=wasm</code></p>
+    <p>Then serve this directory with a local web server (required for Wasm):</p>
+    <pre>python3 -m http.server 8000</pre>
+    <p>Open <a href="http://localhost:8000/wasm_example.html">http://localhost:8000/wasm_example.html</a></p>
+
+    <script src="engine.js"></script>
+    <script>
+        let engine = null;
+        const outputEl = document.getElementById('output');
+        const inputEl = document.getElementById('input');
+
+        function log(text) {
+            outputEl.textContent += text + '\n';
+            outputEl.scrollTop = outputEl.scrollHeight;
+        }
+
+        async function initEngine() {
+            log('Loading PlentyChess WebAssembly...');
+            try {
+                // PlentyChess is the factory function loaded via script tag
+                engine = await PlentyChess();
+
+                // Initialize the engine
+                engine._wasm_init();
+                log('Engine initialized successfully!');
+
+                // Get initial output
+                const output = engine.UTF8ToString(engine._wasm_get_output());
+                if (output) log(output);
+
+            } catch (e) {
+                log('Error loading engine: ' + e.message);
+                console.error(e);
+                log('Make sure to build with: make arch=wasm-simd');
+            }
+        }
+
+        function sendCommand(cmd) {
+            if (!engine) {
+                log('Engine not loaded yet!');
+                return;
+            }
+
+            log('> ' + cmd);
+
+            // Send command to engine - allocate string on heap
+            const cmdLen = engine.lengthBytesUTF8(cmd) + 1;
+            const cmdPtr = engine._malloc(cmdLen);
+            engine.stringToUTF8(cmd, cmdPtr, cmdLen);
+            engine._wasm_send_command(cmdPtr);
+            engine._free(cmdPtr);
+
+            // Process the command
+            engine._wasm_process_commands();
+
+            // Get output
+            setTimeout(() => {
+                const output = engine.UTF8ToString(engine._wasm_get_output());
+                if (output) log(output);
+            }, 10);
+        }
+
+        function handleKeyPress(event) {
+            if (event.key === 'Enter') {
+                const cmd = inputEl.value.trim();
+                if (cmd) {
+                    sendCommand(cmd);
+                    inputEl.value = '';
+                }
+            }
+        }
+
+        // Initialize on load
+        initEngine();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `wasm` and `wasm-simd` architecture targets for building with Emscripten
- Wasm SIMD128 intrinsics for NNUE evaluation
- Single-threaded mode (Wasm pthreads require SharedArrayBuffer restrictions)
- Syzygy tablebases disabled (Fathom uses mmap)
- Command queue I/O model for browser integration
- Includes browser demo (`wasm_example.html`)

## Build
```bash
source /path/to/emsdk/emsdk_env.sh
make arch=wasm-simd
python3 -m http.server 8000
```

## Limitations
- Single-threaded only
- Deep searches block browser UI (use `go depth 10` or `go movetime 2000`)

🤖 Generated with [Claude Code](https://claude.ai/code)