### PR TITLE
Don't overwrite useful TT data in stand pat

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,7 +514,7 @@ Eval Worker::qsearch(Board* board, SearchStack* stack, Eval alpha, Eval beta) {
     if (bestValue >= beta) {
         if (std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY)
             bestValue = (bestValue + beta) / 2;
-        ttEntry->update(fmrHash, Move::none(), ttEntry->depth, unadjustedEval, bestValue, board->rule50_ply, ttPv, TT_LOWERBOUND);
+        ttEntry->update(fmrHash, Move::none(), ttEntry->depth, unadjustedEval, ttValue, board->rule50_ply, ttPv, ttFlag);
         return bestValue;
     }
     if (alpha < bestValue)

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.50";
+constexpr auto VERSION = "7.0.51";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 0.91 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.94 (-2.25, 2.89) [0.00, 2.50]
Games | N: 76874 W: 19009 L: 18808 D: 39057
Penta | [113, 8792, 20430, 8985, 117]
https://furybench.com/test/4674/
```

Bench: 2807950