### PR TITLE
Add inCheck and capture dimensions to continuation history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -30,7 +30,7 @@ public:
 
     int16_t quietHistory[2][64][2][64][2];
 
-    int16_t continuationHistory[2][Piece::TOTAL][64][Piece::TOTAL * 64 * 2];
+    int16_t continuationHistory[2][2][2][Piece::TOTAL][64][Piece::TOTAL * 64 * 2];
     int16_t continuationCorrectionHistory[2][Piece::TOTAL][64][2][2];
 
     void initHistory();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -564,7 +564,7 @@ movesLoopQsearch:
         stack->capture = capture;
         stack->move = move;
         stack->movedPiece = board->pieces[origin];
-        stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+        stack->contHist = history.continuationHistory[!!board->checkers][capture][board->stm][stack->movedPiece][target];
         stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target][board->isSquareThreatened(origin)][board->isSquareThreatened(target)];
 
         playedQuiet |= move != ttMove && !capture;
@@ -838,7 +838,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
         stack->capture = false;
         stack->move = Move::none();
         stack->movedPiece = Piece::NONE;
-        stack->contHist = history.continuationHistory[board->stm][0][0];
+        stack->contHist = history.continuationHistory[0][0][board->stm][0][0];
         stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][0][0][0][0];
         int R = nmpRedBase + 100 * depth / nmpDepthDiv + std::min(100 * (eval - beta) / nmpDivisor, nmpMin);
 
@@ -892,7 +892,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
             stack->capture = board->isCapture(move);
             stack->move = move;
             stack->movedPiece = board->pieces[origin];
-            stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+            stack->contHist = history.continuationHistory[!!board->checkers][stack->capture][board->stm][stack->movedPiece][target];
             stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target][board->isSquareThreatened(origin)][board->isSquareThreatened(target)];;
 
             Board* boardCopy = doMove(board, newHash, move);
@@ -1074,7 +1074,7 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
         stack->capture = capture;
         stack->move = move;
         stack->movedPiece = board->pieces[origin];
-        stack->contHist = history.continuationHistory[board->stm][stack->movedPiece][target];
+        stack->contHist = history.continuationHistory[!!board->checkers][capture][board->stm][stack->movedPiece][target];
         stack->contCorrHist = &history.continuationCorrectionHistory[board->stm][stack->movedPiece][target][board->isSquareThreatened(origin)][board->isSquareThreatened(target)];;
 
         moveCount++;

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.51";
+constexpr auto VERSION = "7.0.52";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Huge thanks to @peregrineshahin for suggesting this idea to me.

STC
```
Elo   | -0.24 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.05 (-2.25, 2.89) [0.00, 2.50]
Games | N: 29502 W: 7263 L: 7283 D: 14956
Penta | [49, 3431, 7802, 3429, 40]
https://furybench.com/test/4701/
```
LTC
```
Elo   | 2.16 +- 1.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 41522 W: 10451 L: 10193 D: 20878
Penta | [5, 4374, 11755, 4612, 15]
https://furybench.com/test/4706/
```

Bench: 2737052