### PR TITLE
Bugfix: Treat PV nodes properly in qsearch

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.52";
+constexpr auto VERSION = "7.0.53";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
Due to a bug, there were never any qsearch nodes marked as PV nodes, despite many nodes having non-zero windows

Failed STC
```
Elo   | -0.40 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 2.50]
Games | N: 52480 W: 12815 L: 12876 D: 26789
Penta | [50, 6020, 14179, 5923, 68]
https://furybench.com/test/4849/
```
Passed LTC non-regression
```
Elo   | 3.63 +- 3.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 9944 W: 2502 L: 2398 D: 5044
Penta | [3, 1010, 2841, 1116, 2]
https://furybench.com/test/4938/
```

Bench: 2695877