### PR TITLE
Speedup: Prefetch threat weights

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -247,6 +247,7 @@ void NNUE::incrementallyUpdateThreatFeatures(Accumulator* inputAcc, Accumulator*
 
         int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare & 0b111111, kingBucket->mirrored);
         if (featureIndex < ThreatInputs::FEATURE_COUNT) {
+            __builtin_prefetch(&networkData->inputThreatWeights[featureIndex * L1_SIZE]);
             (add ? addFeatures : subFeatures).add(featureIndex);
         }
     }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.53";
+constexpr auto VERSION = "7.0.54";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
```
Elo   | 5.10 +- 2.69 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 15462 W: 3849 L: 3622 D: 7991
Penta | [38, 1588, 4261, 1797, 47]
```
https://furybench.com/test/5014/

Bench: 2695877