### PR TITLE
Also apply fail-firm in qsearch pv-nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -602,7 +602,7 @@ movesLoopQsearch:
         bestValue = matedIn(stack->ply); // Checkmate
     }
 
-    if (!pvNode && std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY && bestValue >= beta) {
+    if (std::abs(bestValue) < EVAL_TBWIN_IN_MAX_PLY && std::abs(beta) < EVAL_TBWIN_IN_MAX_PLY && bestValue >= beta) {
         bestValue = (bestValue + beta) / 2;
     }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.54";
+constexpr auto VERSION = "7.0.55";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 0.81 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.02 (-2.25, 2.89) [0.00, 2.50]
Games | N: 120068 W: 29422 L: 29141 D: 61505
Penta | [127, 13705, 32119, 13926, 157]
```
https://furybench.com/test/4946/
LTC
```
Elo   | 1.05 +- 0.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.20 (-2.25, 2.89) [0.00, 2.50]
Games | N: 104068 W: 26040 L: 25726 D: 52302
Penta | [18, 10852, 29977, 11172, 15]
```
https://furybench.com/test/4947/

Bench: 2989958