### PR TITLE
Use history to adjust LMP margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -949,9 +949,9 @@ Eval Worker::search(Board* board, SearchStack* stack, Depth depth, Eval alpha, E
             if (!pvNode && !capture) {
                 int lmpMargin;
                 if (improving)
-                    lmpMargin = 3863191 + 77 * depth * depth + 1500 * depth;
+                    lmpMargin = 3863191 + 77 * depth * depth + 1500 * depth + moveHistory;
                 else
-                    lmpMargin = 2958636 + 16 * depth * depth + 4500 * depth;
+                    lmpMargin = 2958636 + 16 * depth * depth + 4500 * depth + moveHistory;
 
                 if (moveCount >= lmpMargin / 1000000) {
                     movegen.skipQuietMoves();

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.64";
+constexpr auto VERSION = "7.0.65";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.53 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 2.50]
Games | N: 80162 W: 19592 L: 19239 D: 41331
Penta | [139, 9376, 20721, 9683, 162]
```
https://furybench.com/test/5808/
LTC
```
Elo   | 1.53 +- 2.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.01 (-2.25, 2.89) [0.00, 2.50]
Games | N: 25160 W: 6117 L: 6006 D: 13037
Penta | [9, 2831, 6783, 2954, 3]
```
https://furybench.com/test/5813/

Bench: 3410013