### PR TITLE
Allow SEE pruning and noisy LMP in qsearch when in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -528,8 +528,8 @@ movesLoopQsearch:
         if (!capture && playedQuiet && bestValue > -EVAL_TBWIN_IN_MAX_PLY)
             continue;
 
-        if (futilityValue > -EVAL_INFINITE && bestValue > -EVAL_TBWIN_IN_MAX_PLY) { // Only prune when not in check
-            if (futilityValue <= alpha && !SEE(board, move, 1)) {
+        if (bestValue > -EVAL_TBWIN_IN_MAX_PLY) {
+            if (futilityValue > -EVAL_INFINITE && futilityValue <= alpha && !SEE(board, move, 1)) {
                 bestValue = std::max(bestValue, futilityValue);
                 continue;
             }

--- a/src/uci.h
+++ b/src/uci.h
@@ -4,7 +4,7 @@
 
 #include "nnue.h"
 
-constexpr auto VERSION = "7.0.65";
+constexpr auto VERSION = "7.0.66";
 
 template<int... Is>
 struct seq { };


### PR DESCRIPTION
STC
```
Elo   | 1.94 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 53794 W: 13301 L: 13001 D: 27492
Penta | [76, 6262, 13943, 6518, 98]
```
https://furybench.com/test/6142/
LTC
```
Elo   | 2.01 +- 1.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.74 (-2.25, 2.89) [0.00, 2.50]
Games | N: 44690 W: 10856 L: 10597 D: 23237
Penta | [9, 4943, 12185, 5196, 12]
```
https://furybench.com/test/6145/

Bench: 4265917