### PR TITLE
Speed up NNZ and threats computation with VBMI2

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -206,9 +206,15 @@ std::string Board::fen() {
 }
 
 template<bool add, bool computeRays>
-__always_inline void Board::updatePieceThreats(Piece piece, Color pieceColor, Square square, NNUE* nnue, Bitboard allowedRayUpdates) {
+__always_inline void Board::updatePieceThreats(Piece piece, Color pieceColor, Square square, NNUE* nnue, Square ignore) {
+#if defined(__AVX512VBMI2__)
+    nnue->updatePieceThreatsGeometry<add, computeRays>(this, piece, pieceColor, square, ignore);
+    return;
+#endif
+    Bitboard ignoreBB = ignore != NO_SQUARE ? bitboard(ignore) : 0;
+
     // Process attacks of the current piece to other pieces
-    Bitboard occupancy = byColor[Color::WHITE] | byColor[Color::BLACK];
+    Bitboard occupancy = (byColor[Color::WHITE] | byColor[Color::BLACK]) & ~ignoreBB;
     Bitboard attacked = BB::attackedSquares(piece, square, occupancy, pieceColor) & occupancy;
     while (attacked) {
         Square attackedSquare = popLSB(&attacked);
@@ -226,11 +232,12 @@ __always_inline void Board::updatePieceThreats(Piece piece, Color pieceColor, Sq
 
     Bitboard slidingPieces = (byPiece[Piece::BISHOP] | byPiece[Piece::QUEEN]) & bishopAttacks;
     slidingPieces |= (byPiece[Piece::ROOK] | byPiece[Piece::QUEEN]) & rookAttacks;
+    slidingPieces &= ~ignoreBB;
 
     Bitboard attackingPawns = byPiece[Piece::PAWN] & ((byColor[Color::BLACK] & BB::pawnAttacks(bitboard(square), Color::WHITE)) | (byColor[Color::WHITE] & BB::pawnAttacks(bitboard(square), Color::BLACK)));
     Bitboard attackingKnights = byPiece[Piece::KNIGHT] & BB::KNIGHT_ATTACKS[square];
     Bitboard attackingKings = byPiece[Piece::KING] & BB::KING_ATTACKS[square];
-    Bitboard incomingThreats = attackingPawns | attackingKnights | attackingKings;
+    Bitboard incomingThreats = (attackingPawns | attackingKnights | attackingKings) & ~ignoreBB;
 
     // Process attacks of sliding pieces that are now blocked by this piece
     if (computeRays) {
@@ -245,7 +252,7 @@ __always_inline void Board::updatePieceThreats(Piece piece, Color pieceColor, Sq
 
             assert(BB::popcount(threatened) < 2);
 
-            if (threatened && (ray & allowedRayUpdates) != allowedRayUpdates) {
+            if (threatened) {
                 Square attackedSquare = lsb(threatened);
                 Piece attackedPiece = pieces[attackedSquare];
                 Color attackedColor = (bitboard(attackedSquare) & byColor[Color::WHITE]) ? Color::WHITE : Color::BLACK;
@@ -331,15 +338,14 @@ void Board::movePiece(Piece piece, Color pieceColor, Square origin, Square targe
     assert(pieces[target] == Piece::NONE);
     
     Bitboard fromTo = bitboard(origin) ^ bitboard(target);
-    updatePieceThreats<false>(piece, pieceColor, origin, nnue, fromTo);
-
     byColor[pieceColor] ^= fromTo;
     byPiece[piece] ^= fromTo;
 
     pieces[origin] = Piece::NONE;
     pieces[target] = piece;
 
-    updatePieceThreats<true>(piece, pieceColor, target, nnue, fromTo);
+    updatePieceThreats<false>(piece, pieceColor, origin, nnue, target);
+    updatePieceThreats<true>(piece, pieceColor, target, nnue);
     updatePieceHash(piece, pieceColor, Zobrist::PIECE_SQUARES[pieceColor][piece][origin] ^ Zobrist::PIECE_SQUARES[pieceColor][piece][target]);
     updatePieceCastling(piece, pieceColor, origin);
 }

--- a/src/board.h
+++ b/src/board.h
@@ -91,7 +91,7 @@ struct Board {
     std::string fen();
 
     template<bool add, bool computeRays = true>
-    __always_inline void updatePieceThreats(Piece piece, Color pieceColor, Square square, NNUE* nnue, Bitboard allowedRayUpdates = ~bitboard(0));
+    __always_inline void updatePieceThreats(Piece piece, Color pieceColor, Square square, NNUE* nnue, Square ignore = NO_SQUARE);
     void updatePieceHash(Piece piece, Color pieceColor, uint64_t hashDelta);
     void updatePieceCastling(Piece piece, Color pieceColor, Square origin);
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -438,6 +438,22 @@ Eval NNUE::evaluate(Board* board) {
     alignas(ALIGNMENT) uint16_t nnzIndices[L1_SIZE / INT8_PER_INT32];
 
     VecI32* pairwiseOutputsVecI32 = reinterpret_cast<VecI32*>(pairwiseOutputs);
+
+#if defined(__AVX512VBMI2__)
+    VecIu16 nnzBase = _mm512_set_epi16(
+        31, 30, 29, 28, 27, 26, 25, 24,
+        23, 22, 21, 20, 19, 18, 17, 16,
+        15, 14, 13, 12, 11, 10,  9,  8,
+         7,  6,  5,  4,  3,  2,  1,  0
+    );
+    for (int i = 0; i < L1_SIZE / INT8_PER_INT32 / 32; i++) {
+        uint32_t nnzMask = vecNNZ(pairwiseOutputsVecI32[i * 2]) | (vecNNZ(pairwiseOutputsVecI32[i * 2 + 1]) << 16);
+        _mm512_storeu_si512(nnzIndices + nnzCount, _mm512_maskz_compress_epi16(nnzMask, nnzBase));
+        nnzBase = _mm512_add_epi16(nnzBase, _mm512_set1_epi16(32));
+        nnzCount += __builtin_popcount(nnzMask);
+    }
+#else
+compile error:)))))
     VecI16_v128 nnzZero = setZero_v128();
     VecI16_v128 nnzIncrement = set1Epi16_v128(8);
     for (int i = 0; i < L1_SIZE / INT8_PER_INT32 / 16; i++) {
@@ -455,6 +471,7 @@ Eval NNUE::evaluate(Board* board) {
             nnzZero = addEpi16_v128(nnzZero, nnzIncrement);
         }
     }
+#endif
 
     // ---------------------- SPARSE L1 PROPAGATION ----------------------
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -497,7 +497,6 @@ Eval NNUE::evaluate(Board* board) {
         nnzCount += __builtin_popcount(nnzMask);
     }
 #else
-compile error:)))))
     VecI16_v128 nnzZero = setZero_v128();
     VecI16_v128 nnzIncrement = set1Epi16_v128(8);
     for (int i = 0; i < L1_SIZE / INT8_PER_INT32 / 16; i++) {

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -287,18 +287,14 @@ void NNUE::incrementallyUpdateThreatFeatures(Accumulator* inputAcc, Accumulator*
     for (int dp = 0; dp < outputAcc->numThreatsAdded; dp++) {
         DirtyThreat& dt = outputAcc->dirtyThreatsAdded[dp];
         int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare, kingBucket->mirrored);
-        if (featureIndex < ThreatInputs::FEATURE_COUNT) {
-            __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
-            adds.add(ThreatInputs::THREAT_OFFSET + featureIndex);
-        }
+        __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
+        adds.addIf(ThreatInputs::THREAT_OFFSET + featureIndex, featureIndex < ThreatInputs::FEATURE_COUNT);
     }
     for (int dp = 0; dp < outputAcc->numThreatsRemoved; dp++) {
         DirtyThreat& dt = outputAcc->dirtyThreatsRemoved[dp];
         int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare, kingBucket->mirrored);
-        if (featureIndex < ThreatInputs::FEATURE_COUNT) {
-            __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
-            subs.add(ThreatInputs::THREAT_OFFSET + featureIndex);
-        }
+        __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
+        subs.addIf(ThreatInputs::THREAT_OFFSET + featureIndex, featureIndex < ThreatInputs::FEATURE_COUNT);
     }
 
     if (!adds.size() && !subs.size()) {

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -6,6 +6,7 @@
 
 #include "nnue.h"
 #include "board.h"
+#include "threat-geometry.h"
 
 #if defined(ARCH_ARM)
 #include <arm_neon.h>
@@ -59,7 +60,8 @@ void NNUE::reset(Board* board) {
     // Reset accumulator
     resetAccumulator<Color::WHITE>(board, &accumulatorStack[0]);
     resetAccumulator<Color::BLACK>(board, &accumulatorStack[0]);
-    accumulatorStack[0].numDirtyThreats = 0;
+    accumulatorStack[0].numThreatsAdded = 0;
+    accumulatorStack[0].numThreatsRemoved = 0;
 
     currentAccumulator = 0;
     lastCalculatedAccumulator[Color::WHITE] = 0;
@@ -102,12 +104,52 @@ void NNUE::updateThreat(Piece piece, Piece attackedPiece, Square square, Square 
     assert(attackedPiece != Piece::NONE);
 
     Accumulator* acc = &accumulatorStack[currentAccumulator];
-    acc->dirtyThreats[acc->numDirtyThreats++] = DirtyThreat(piece, pieceColor, attackedPiece, attackedColor, square, attackedSquare, add);
+    DirtyThreat threat(piece, pieceColor, attackedPiece, attackedColor, square, attackedSquare);
+    if (add)
+        acc->dirtyThreatsAdded[acc->numThreatsAdded++] = threat;
+    else
+        acc->dirtyThreatsRemoved[acc->numThreatsRemoved++] = threat;
 }
+
+#if defined(__AVX512VBMI2__)
+template<bool add, bool computeRays>
+void NNUE::updatePieceThreatsGeometry(Board* board, Piece piece, Color pieceColor, Square square, Square ignore) {
+    using namespace ThreatGeometry;
+    Accumulator* acc = &accumulatorStack[currentAccumulator];
+    uint8_t colouredPiece = static_cast<uint8_t>(piece | (pieceColor << 3));
+
+    __m512i mailbox = colouredMailbox((const uint8_t*)board->pieces, board->byColor[Color::BLACK]);
+    if (ignore != NO_SQUARE)
+        mailbox = _mm512_mask_blend_epi8(1ULL << ignore, mailbox, _mm512_set1_epi8(Piece::NONE));
+    Permutation perm = permutationFor(square);
+    auto [permuted, bits] = permuteMailbox(perm, mailbox);
+    Bitrays closest = closestOccupied(bits);
+
+    int& focusCount = add ? acc->numThreatsAdded : acc->numThreatsRemoved;
+    DirtyThreat* focusList = add ? acc->dirtyThreatsAdded : acc->dirtyThreatsRemoved;
+    focusCount += pushFocusThreats<true>(focusList + focusCount, perm.indexes, permuted, outgoingThreats(colouredPiece, closest), colouredPiece, square);
+    focusCount += pushFocusThreats<false>(focusList + focusCount, perm.indexes, permuted, incomingAttackers(bits, closest), colouredPiece, square);
+
+    if constexpr (computeRays) {
+        Bitrays sliders = incomingSliders(bits, closest);
+        Bitrays masked = closest & 0xFEFEFEFEFEFEFEFEULL;
+        Bitrays victims = (masked >> 32) | (masked << 32);
+        Bitrays valid = rayFill(victims) & rayFill(sliders);
+        int& discCount = add ? acc->numThreatsRemoved : acc->numThreatsAdded;
+        DirtyThreat* discList = add ? acc->dirtyThreatsRemoved : acc->dirtyThreatsAdded;
+        discCount += pushDiscoveredThreats(discList + discCount, perm.indexes, permuted, sliders & valid, victims & valid);
+    }
+}
+template void NNUE::updatePieceThreatsGeometry<true, true>(Board*, Piece, Color, Square, Square);
+template void NNUE::updatePieceThreatsGeometry<true, false>(Board*, Piece, Color, Square, Square);
+template void NNUE::updatePieceThreatsGeometry<false, true>(Board*, Piece, Color, Square, Square);
+template void NNUE::updatePieceThreatsGeometry<false, false>(Board*, Piece, Color, Square, Square);
+#endif
 
 void NNUE::incrementAccumulator() {
     currentAccumulator++;
-    accumulatorStack[currentAccumulator].numDirtyThreats = 0;
+    accumulatorStack[currentAccumulator].numThreatsAdded = 0;
+    accumulatorStack[currentAccumulator].numThreatsRemoved = 0;
 }
 
 void NNUE::decrementAccumulator() {
@@ -242,14 +284,20 @@ void NNUE::incrementallyUpdateThreatFeatures(Accumulator* inputAcc, Accumulator*
     ThreatInputs::FeatureList adds, subs;
     ThreatInputs::addPawnPairDeltas<side>(outputAcc->board, outputAcc->dirtyPiece, kingBucket->mirrored, adds, subs);
 
-    for (int dp = 0; dp < outputAcc->numDirtyThreats; dp++) {
-        DirtyThreat& dt = outputAcc->dirtyThreats[dp];
-        bool add = dt.attackedSquare >> 7;
-
-        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare & 0b111111, kingBucket->mirrored);
+    for (int dp = 0; dp < outputAcc->numThreatsAdded; dp++) {
+        DirtyThreat& dt = outputAcc->dirtyThreatsAdded[dp];
+        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare, kingBucket->mirrored);
         if (featureIndex < ThreatInputs::FEATURE_COUNT) {
             __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
-            (add ? adds : subs).add(ThreatInputs::THREAT_OFFSET + featureIndex);
+            adds.add(ThreatInputs::THREAT_OFFSET + featureIndex);
+        }
+    }
+    for (int dp = 0; dp < outputAcc->numThreatsRemoved; dp++) {
+        DirtyThreat& dt = outputAcc->dirtyThreatsRemoved[dp];
+        int featureIndex = ThreatInputs::getThreatFeature<side>(dt.piece, dt.attackedPiece, dt.square, dt.attackedSquare, kingBucket->mirrored);
+        if (featureIndex < ThreatInputs::FEATURE_COUNT) {
+            __builtin_prefetch(&networkData->inputThreatWeights[(ThreatInputs::THREAT_OFFSET + featureIndex) * L1_SIZE]);
+            subs.add(ThreatInputs::THREAT_OFFSET + featureIndex);
         }
     }
 

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -51,17 +51,17 @@ enum class FtType {
 
 struct DirtyThreat {
   uint8_t piece;
-  uint8_t attackedPiece;
   Square square;
+  uint8_t attackedPiece;
   uint8_t attackedSquare;
 
   DirtyThreat() = default;
 
-  DirtyThreat(Piece _piece, Color _pieceColor, Piece _attackedPiece, Color _attackedPieceColor, Square _square, Square _attackedSquare, bool _add) {
+  DirtyThreat(Piece _piece, Color _pieceColor, Piece _attackedPiece, Color _attackedPieceColor, Square _square, Square _attackedSquare) {
     piece = static_cast<uint8_t>(_piece | (_pieceColor << 3));
-    attackedPiece = static_cast<uint8_t>(_attackedPiece | (_attackedPieceColor << 3));
     square = _square;
-    attackedSquare = static_cast<uint8_t>(_attackedSquare | (_add << 7));
+    attackedPiece = static_cast<uint8_t>(_attackedPiece | (_attackedPieceColor << 3));
+    attackedSquare = _attackedSquare;
   }
 
 };
@@ -85,8 +85,10 @@ struct Accumulator {
   alignas(ALIGNMENT) int16_t pieceState[2][L1_SIZE];
 
   DirtyPiece dirtyPiece;
-  DirtyThreat dirtyThreats[256];
-  int numDirtyThreats;
+  DirtyThreat dirtyThreatsAdded[128];
+  DirtyThreat dirtyThreatsRemoved[128];
+  int numThreatsAdded;
+  int numThreatsRemoved;
 
   KingBucketInfo kingBucketInfo[2];
   Board* board;
@@ -134,6 +136,11 @@ public:
   FinnyEntry finnyTable[2][KING_BUCKETS];
 
   void updateThreat(Piece piece, Piece attackedPiece, Square square, Square attackedSquare, Color pieceColor, Color attackedColor, bool add);
+
+#if defined(__AVX512VBMI2__)
+  template<bool add, bool computeRays>
+  void updatePieceThreatsGeometry(Board* board, Piece piece, Color pieceColor, Square square, Square ignore);
+#endif
 
   void incrementAccumulator();
   void decrementAccumulator();

--- a/src/threat-geometry-vbmi2.h
+++ b/src/threat-geometry-vbmi2.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <immintrin.h>
+#include <utility>
+
+namespace ThreatGeometry {
+
+    struct Vector {
+        __m512i raw;
+        Vector flip() const { return {_mm512_shuffle_i64x2(raw, raw, 0b01001110)}; }
+    };
+
+    struct Permutation {
+        Vector indexes;
+        Bitrays valid;
+    };
+
+    inline Permutation permutationFor(Square focus) {
+        __m512i indexes = _mm512_loadu_si512(PERMUTATION_TABLE[focus].data());
+        return {{indexes}, _mm512_testn_epi8_mask(indexes, _mm512_set1_epi8(0x80))};
+    }
+
+    inline __m512i colouredMailbox(const uint8_t* pieces, uint64_t black) {
+        __m512i types = _mm512_loadu_si512(pieces);
+        return _mm512_mask_add_epi8(types, black, types, _mm512_set1_epi8(8));
+    }
+
+    inline std::pair<Vector, Vector> permuteMailbox(const Permutation& permutation, __m512i mailbox) {
+        __m512i lut = _mm512_broadcast_i32x4(_mm_loadu_si128(reinterpret_cast<const __m128i*>(PIECE_TO_BIT.data())));
+        __m512i permuted = _mm512_permutexvar_epi8(permutation.indexes.raw, mailbox);
+        __m512i bits = _mm512_maskz_shuffle_epi8(permutation.valid, lut, permuted);
+        return {{permuted}, {bits}};
+    }
+
+    inline Bitrays closestOccupied(Vector bits) {
+        Bitrays occupied = _mm512_test_epi8_mask(bits.raw, bits.raw);
+        Bitrays o = occupied | 0x8181818181818181ULL;
+        return (o ^ (o - 0x0303030303030303ULL)) & occupied;
+    }
+
+    inline Bitrays rayFill(Bitrays br) {
+        br = (br + 0x7E7E7E7E7E7E7E7EULL) & 0x8080808080808080ULL;
+        return br - (br >> 7);
+    }
+
+    inline Bitrays outgoingThreats(uint8_t colouredPiece, Bitrays closest) {
+        return OUTGOING_THREATS[colouredPiece] & closest;
+    }
+
+    inline Bitrays incomingAttackers(Vector bits, Bitrays closest) {
+        return _mm512_test_epi8_mask(bits.raw, _mm512_loadu_si512(INCOMING_THREATS_MASK.data())) & closest;
+    }
+
+    inline Bitrays incomingSliders(Vector bits, Bitrays closest) {
+        return _mm512_test_epi8_mask(bits.raw, _mm512_loadu_si512(INCOMING_SLIDERS_MASK.data())) & closest & 0xFEFEFEFEFEFEFEFEULL;
+    }
+
+    template<bool outgoing>
+    inline int pushFocusThreats(void* dst, Vector indexes, Vector pieces, Bitrays br, uint8_t focusPiece, uint8_t focusSquare) {
+        const __m512i pair2Shuffle = _mm512_set_epi8(
+            79, 15, 79, 15, 78, 14, 78, 14, 77, 13, 77, 13, 76, 12, 76, 12, 75, 11, 75, 11,
+            74, 10, 74, 10, 73, 9, 73, 9, 72, 8, 72, 8, 71, 7, 71, 7, 70, 6, 70, 6, 69, 5,
+            69, 5, 68, 4, 68, 4, 67, 3, 67, 3, 66, 2, 66, 2, 65, 1, 65, 1, 64, 0, 64, 0
+        );
+        __m512i focus = _mm512_set1_epi16(static_cast<int16_t>(focusPiece | (focusSquare << 8)));
+        __m512i otherSq = _mm512_maskz_compress_epi8(br, indexes.raw);
+        __m512i otherPiece = _mm512_maskz_compress_epi8(br, pieces.raw);
+        __m512i other = _mm512_permutex2var_epi8(otherPiece, pair2Shuffle, otherSq);
+        constexpr uint64_t mask = outgoing ? 0xCCCCCCCCCCCCCCCCULL : 0x3333333333333333ULL;
+        _mm512_storeu_si512(dst, _mm512_mask_mov_epi8(focus, mask, other));
+        return __builtin_popcountll(br);
+    }
+
+    inline int pushDiscoveredThreats(void* dst, Vector indexes, Vector pieces, Bitrays sliders, Bitrays victims) {
+        __m128i sliderPiece = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders, pieces.raw));
+        __m128i sliderSq = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders, indexes.raw));
+        __m128i victimPiece = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims, pieces.flip().raw));
+        __m128i victimSq = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims, indexes.flip().raw));
+        __m128i sliderPair = _mm_unpacklo_epi8(sliderPiece, sliderSq);
+        __m128i victimPair = _mm_unpacklo_epi8(victimPiece, victimSq);
+        _mm_storeu_si128(static_cast<__m128i*>(dst), _mm_unpacklo_epi16(sliderPair, victimPair));
+        _mm_storeu_si128(static_cast<__m128i*>(dst) + 1, _mm_unpackhi_epi16(sliderPair, victimPair));
+        return __builtin_popcountll(victims);
+    }
+
+}

--- a/src/threat-geometry.h
+++ b/src/threat-geometry.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "types.h"
+
+#if defined(__AVX512VBMI2__)
+
+namespace ThreatGeometry {
+
+    using Bitrays = uint64_t;
+
+    constexpr uint8_t BIT_BLACK_PAWN = 0x01;
+    constexpr uint8_t BIT_WHITE_PAWN = 0x02;
+    constexpr uint8_t BIT_KNIGHT = 0x04;
+    constexpr uint8_t BIT_BISHOP = 0x08;
+    constexpr uint8_t BIT_ROOK = 0x10;
+    constexpr uint8_t BIT_QUEEN = 0x20;
+    constexpr uint8_t BIT_KING = 0x40;
+
+    inline constexpr std::array<std::array<uint8_t, 64>, 64> PERMUTATION_TABLE = [] {
+        constexpr int rayRank[8] = {1, 1, 0, -1, -1, -1, 0, 1};
+        constexpr int rayFile[8] = {0, 1, 1, 1, 0, -1, -1, -1};
+        constexpr int knightRank[8] = {2, 2, 1, -1, -2, -2, -1, 1};
+        constexpr int knightFile[8] = {-1, 1, 2, 2, 1, -1, -2, -2};
+
+        std::array<std::array<uint8_t, 64>, 64> table{};
+        for (int focus = 0; focus < 64; focus++) {
+            int rank = focus / 8, file = focus % 8;
+            auto square = [](int r, int f) -> uint8_t {
+                return (r >= 0 && r < 8 && f >= 0 && f < 8) ? uint8_t(r * 8 + f) : 0x80;
+            };
+            for (int dir = 0; dir < 8; dir++) {
+                table[focus][dir * 8] = square(rank + knightRank[dir], file + knightFile[dir]);
+                for (int dist = 1; dist < 8; dist++)
+                    table[focus][dir * 8 + dist] = square(rank + rayRank[dir] * dist, file + rayFile[dir] * dist);
+            }
+        }
+        return table;
+    }();
+
+    inline constexpr std::array<uint8_t, 16> PIECE_TO_BIT = {
+        BIT_WHITE_PAWN, BIT_KNIGHT, BIT_BISHOP, BIT_ROOK, BIT_QUEEN, BIT_KING, 0, 0,
+        BIT_BLACK_PAWN, BIT_KNIGHT, BIT_BISHOP, BIT_ROOK, BIT_QUEEN, BIT_KING, 0, 0,
+    };
+
+    inline constexpr std::array<Bitrays, 16> OUTGOING_THREATS = {
+        0x0200000000000200ULL, 0x0101010101010101ULL, 0xFE00FE00FE00FE00ULL, 0x00FE00FE00FE00FEULL, 0xFEFEFEFEFEFEFEFEULL, 0, 0, 0,
+        0x0000020002000000ULL, 0x0101010101010101ULL, 0xFE00FE00FE00FE00ULL, 0x00FE00FE00FE00FEULL, 0xFEFEFEFEFEFEFEFEULL, 0, 0, 0,
+    };
+
+    inline constexpr std::array<uint8_t, 64> INCOMING_THREATS_MASK = [] {
+        constexpr uint8_t horse = BIT_KNIGHT;
+        constexpr uint8_t orth = BIT_QUEEN | BIT_ROOK;
+        constexpr uint8_t diag = BIT_QUEEN | BIT_BISHOP;
+        constexpr uint8_t wPawnNear = BIT_WHITE_PAWN | diag;
+        constexpr uint8_t bPawnNear = BIT_BLACK_PAWN | diag;
+        return std::array<uint8_t, 64>{
+            horse, orth, orth, orth, orth, orth, orth, orth,       // N
+            horse, bPawnNear, diag, diag, diag, diag, diag, diag,  // NE
+            horse, orth, orth, orth, orth, orth, orth, orth,       // E
+            horse, wPawnNear, diag, diag, diag, diag, diag, diag,  // SE
+            horse, orth, orth, orth, orth, orth, orth, orth,       // S
+            horse, wPawnNear, diag, diag, diag, diag, diag, diag,  // SW
+            horse, orth, orth, orth, orth, orth, orth, orth,       // W
+            horse, bPawnNear, diag, diag, diag, diag, diag, diag,  // NW
+        };
+    }();
+
+    inline constexpr std::array<uint8_t, 64> INCOMING_SLIDERS_MASK = [] {
+        constexpr uint8_t orth = BIT_QUEEN | BIT_ROOK;
+        constexpr uint8_t diag = BIT_QUEEN | BIT_BISHOP;
+        return std::array<uint8_t, 64>{
+            0x80, orth, orth, orth, orth, orth, orth, orth, // N
+            0x80, diag, diag, diag, diag, diag, diag, diag, // NE
+            0x80, orth, orth, orth, orth, orth, orth, orth, // E
+            0x80, diag, diag, diag, diag, diag, diag, diag, // SE
+            0x80, orth, orth, orth, orth, orth, orth, orth, // S
+            0x80, diag, diag, diag, diag, diag, diag, diag, // SW
+            0x80, orth, orth, orth, orth, orth, orth, orth, // W
+            0x80, diag, diag, diag, diag, diag, diag, diag, // NW
+        };
+    }();
+
+}
+
+#include "threat-geometry-vbmi2.h"
+
+#endif

--- a/src/threat-inputs.cpp
+++ b/src/threat-inputs.cpp
@@ -23,7 +23,7 @@ namespace ThreatInputs {
     };
 
     PiecePairData PIECE_PAIR_LOOKUP[14][14];
-    int PIECE_OFFSET_LOOKUP[14][64];
+    uint16_t PIECE_OFFSET_LOOKUP[14][64];
     uint8_t ATTACK_INDEX_LOOKUP[14][64][64];
 
     void initialise() {

--- a/src/types.h
+++ b/src/types.h
@@ -234,6 +234,12 @@ public:
         elements[_size++] = element;
     }
 
+    void addIf(const T& element, bool condition) {
+        assert(_size < MAX);
+        elements[_size] = element;
+        _size += condition;
+    }
+
     T remove(size_t i) {
         T removed = elements[i];
         elements[i] = elements[--_size];


### PR DESCRIPTION
```
Elo   | 1.88 +- 1.45 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 57474 W: 14392 L: 14081 D: 29001
Penta | [189, 6533, 14998, 6812, 205]
```
https://furybench.com/test/6564/

```
Elo   | 7.37 +- 3.37 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 10650 W: 2728 L: 2502 D: 5420
Penta | [28, 1157, 2740, 1361, 39]
```
https://furybench.com/test/6577/

Borrows heavily from the implementation in https://github.com/Ciekce/Stormphrax/ by @87flowers

bench: 3939470