### PR TITLE
Smaller tiling on avx512

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -384,7 +384,7 @@ void NNUE::applyThreatRows(int16_t(*inputData)[L1_SIZE], int16_t(*outputData)[L1
     VecI16* output = (VecI16*)outputData[side];
 
 #if defined(__AVX512F__) && defined(__AVX512BW__)
-    constexpr int TILE = L1_ITERATIONS;
+    constexpr int TILE = L1_ITERATIONS >= 32 ? 16 : L1_ITERATIONS;
 #else
     constexpr int TILE = 8;
 #endif


### PR DESCRIPTION
5% local speedup
```
Elo   | 12.41 +- 9.07 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 0.71 (-2.25, 2.89) [0.00, 2.50]
Games | N: 1512 W: 406 L: 352 D: 754
Penta | [2, 162, 380, 204, 8]
```
https://furybench.com/test/6613/
Bench: 4672328